### PR TITLE
Check different error types in IsConnectionError

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -16,12 +16,12 @@ import (
 
 	"github.com/mongodb/mongo-tools-common/options"
 	"github.com/mongodb/mongo-tools-common/password"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	mopt "go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"fmt"
 	"io"
@@ -267,8 +267,8 @@ func IsConnectionError(err error) bool {
 		return false
 	}
 
-	// The new driver stringifies command errors as "(Name) Message" rather than just "message". Cast to the
-	// CommandError type if possible to extract the correct error message.
+	// The new driver adds extra information to error strings. Cast to different
+	// error types if possible to extract the correct error message.
 	var errMsg string
 	switch e := err.(type) {
 	case mongo.CommandError:

--- a/db/db.go
+++ b/db/db.go
@@ -269,9 +269,14 @@ func IsConnectionError(err error) bool {
 
 	// The new driver stringifies command errors as "(Name) Message" rather than just "message". Cast to the
 	// CommandError type if possible to extract the correct error message.
-	errMsg := err.Error()
-	if cmdErr, ok := err.(mongo.CommandError); ok {
-		errMsg = cmdErr.Message
+	var errMsg string
+	switch e := err.(type) {
+	case mongo.CommandError:
+		errMsg = e.Message
+	case mongo.WriteError:
+		errMsg = e.Message
+	default:
+		errMsg = err.Error()
 	}
 
 	lowerCaseError := strings.ToLower(errMsg)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -8,12 +8,14 @@ package db
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/mongodb/mongo-tools-common/options"
 	"github.com/mongodb/mongo-tools-common/testtype"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.mongodb.org/mongo-driver/mongo"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -232,6 +234,25 @@ func TestGetIndexes(t *testing.T) {
 			provider.DropDatabase("exists")
 			provider.Close()
 		})
+	})
+}
+
+func TestIsConnectionError(t *testing.T) {
+	cmdErr := mongo.CommandError{
+		Name:    "NotMaster",
+		Message: "not master",
+		Code:    10,
+	}
+	we := mongo.WriteError{
+		Message: "not master",
+		Code:    10,
+		Index:   10,
+	}
+
+	Convey("IsConnectionError should check different types of errors", t, func() {
+		So(IsConnectionError(errors.New("not master")), ShouldBeTrue)
+		So(IsConnectionError(cmdErr), ShouldBeTrue)
+		So(IsConnectionError(we), ShouldBeTrue)
 	})
 }
 


### PR DESCRIPTION
Trying to make IsConnectionError more general based on errors when testing mongoimport in Evergreen. The NotMaster error shows up as a write error inside of a bulk write exception rather than as a command error, so this commit has IsConnectionErrors attempt casts to different types.