### PR TITLE
TOOLS-2349 Change Count to EstimatedDocumentCount

### DIFF
--- a/db/query.go
+++ b/db/query.go
@@ -14,18 +14,14 @@ type DeferredQuery struct {
 	LogReplay bool
 }
 
-// Count issues a count command. We don't use the Hint because
-// that's not supported with older servers.
-func (q *DeferredQuery) Count() (int, error) {
-	opt := mopt.Count()
-	filter := q.Filter
-	if filter == nil {
-		filter = bson.D{}
-	}
-	c, err := q.Coll.CountDocuments(nil, filter, opt)
+// EstimatedDocumentCount issues a count command.
+func (q *DeferredQuery) EstimatedDocumentCount() (int, error) {
+	opt := mopt.EstimatedDocumentCount()
+	c, err := q.Coll.EstimatedDocumentCount(nil, opt)
 	return int(c), err
 }
 
+// Iter executes a find query and returns a cursor.
 func (q *DeferredQuery) Iter() (*mongo.Cursor, error) {
 	opts := mopt.Find()
 	if q.Hint != nil {


### PR DESCRIPTION
`DeferredQuery.Count()` was exclusively used in mongodump for calculating the number of documents for progress bars. This PR changes the method to use `Collection.EstimatedDocumentCount()` instead of `Collection.CountDocuments().` It also renames the method to make it clear which type of count is being performed.