### PR TITLE
MGOMIRROR-290 Add MaxBSONSize field to BSONSource

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,6 +41,14 @@
   version = "v4.20"
 
 [[projects]]
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
+
+[[projects]]
   digest = "1:237af0cf68bac89e21af72e6cd6b64f388854895e75f82ad08c6c011e1a8286c"
   name = "github.com/smartystreets/assertions"
   packages = [
@@ -81,7 +89,7 @@
   revision = "73f8eece6fdcd902c185bf651de50f3828bed5ed"
 
 [[projects]]
-  digest = "1:c540afe732e96088051488bc827eadfba64b90a0e803ea61e7ec80907887362e"
+  digest = "1:43a982fb7d68d8bc923ece6671e1d4536245813e6d46f4d0932f056533eb2af7"
   name = "go.mongodb.org/mongo-driver"
   packages = [
     "bson",
@@ -107,6 +115,8 @@
     "x/mongo/driver/connstring",
     "x/mongo/driver/description",
     "x/mongo/driver/dns",
+    "x/mongo/driver/mongocrypt",
+    "x/mongo/driver/mongocrypt/options",
     "x/mongo/driver/operation",
     "x/mongo/driver/session",
     "x/mongo/driver/topology",
@@ -114,8 +124,7 @@
     "x/mongo/driver/wiremessage",
   ]
   pruneopts = "UT"
-  revision = "d42ea7239f0db8a61e77191b9f2730a922459042"
-  version = "v1.1.0"
+  revision = "7490fa5f89ee53bf642ba1969494987bc39a9918"
 
 [[projects]]
   digest = "1:79784b4d6789bbd40f17a9d204051bdd887d889acbbdc24ed8263b3dca28dfbf"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "go.mongodb.org/mongo-driver"
-  version = "v1.1"
+  revision = "7490fa5f89ee53bf642ba1969494987bc39a9918"
 
 [[constraint]]
   name = "github.com/jessevdk/go-flags"

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.x
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## License
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,282 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which when applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// together with the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error that does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface:
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// The returned errors.StackTrace type is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,147 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}

--- a/vendor/go.mongodb.org/mongo-driver/bson/bsoncodec/struct_codec.go
+++ b/vendor/go.mongodb.org/mongo-driver/bson/bsoncodec/struct_codec.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"go.mongodb.org/mongo-driver/bson/bsonrw"
@@ -161,6 +162,13 @@ func (sc *StructCodec) DecodeValue(r DecodeContext, vr bsonrw.ValueReader, val r
 
 		fd, exists := sd.fm[name]
 		if !exists {
+			// if the original name isn't found in the struct description, try again with the name in lowercase
+			// this could match if a BSON tag isn't specified because by default, describeStruct lowercases all field
+			// names
+			fd, exists = sd.fm[strings.ToLower(name)]
+		}
+
+		if !exists {
 			if sd.inlineMap < 0 {
 				// The encoding/json package requires a flag to return on error for non-existent fields.
 				// This functionality seems appropriate for the struct codec.
@@ -195,7 +203,7 @@ func (sc *StructCodec) DecodeValue(r DecodeContext, vr bsonrw.ValueReader, val r
 		}
 		field = field.Addr()
 
-		dctx := DecodeContext{Registry: r.Registry, Truncate: fd.truncate}
+		dctx := DecodeContext{Registry: r.Registry, Truncate: fd.truncate || r.Truncate}
 		if fd.decoder == nil {
 			return ErrNoDecoder{Type: field.Elem().Type()}
 		}

--- a/vendor/go.mongodb.org/mongo-driver/bson/primitive/primitive.go
+++ b/vendor/go.mongodb.org/mongo-driver/bson/primitive/primitive.go
@@ -21,12 +21,17 @@ type Binary struct {
 	Data    []byte
 }
 
-// Equal compaes bp to bp2 and returns true is the are equal.
+// Equal compares bp to bp2 and returns true is the are equal.
 func (bp Binary) Equal(bp2 Binary) bool {
 	if bp.Subtype != bp2.Subtype {
 		return false
 	}
 	return bytes.Equal(bp.Data, bp2.Data)
+}
+
+// IsZero returns if bp is the empty Binary
+func (bp Binary) IsZero() bool {
+	return bp.Subtype == 0 && len(bp.Data) == 0
 }
 
 // Undefined represents the BSON undefined value type.
@@ -50,7 +55,7 @@ func NewDateTimeFromTime(t time.Time) DateTime {
 	return DateTime(t.UnixNano() / 1000000)
 }
 
-// Null repreesnts the BSON null value.
+// Null represents the BSON null value.
 type Null struct{}
 
 // Regex represents a BSON regex value.
@@ -63,9 +68,14 @@ func (rp Regex) String() string {
 	return fmt.Sprintf(`{"pattern": "%s", "options": "%s"}`, rp.Pattern, rp.Options)
 }
 
-// Equal compaes rp to rp2 and returns true is the are equal.
+// Equal compares rp to rp2 and returns true is the are equal.
 func (rp Regex) Equal(rp2 Regex) bool {
 	return rp.Pattern == rp2.Pattern && rp.Options == rp.Options
+}
+
+// IsZero returns if rp is the empty Regex
+func (rp Regex) IsZero() bool {
+	return rp.Pattern == "" && rp.Options == ""
 }
 
 // DBPointer represents a BSON dbpointer value.
@@ -78,9 +88,14 @@ func (d DBPointer) String() string {
 	return fmt.Sprintf(`{"db": "%s", "pointer": "%s"}`, d.DB, d.Pointer)
 }
 
-// Equal compaes d to d2 and returns true is the are equal.
+// Equal compares d to d2 and returns true is the are equal.
 func (d DBPointer) Equal(d2 DBPointer) bool {
 	return d.DB == d2.DB && bytes.Equal(d.Pointer[:], d2.Pointer[:])
+}
+
+// IsZero returns if d is the empty DBPointer
+func (d DBPointer) IsZero() bool {
+	return d.DB == "" && d.Pointer.IsZero()
 }
 
 // JavaScript represents a BSON JavaScript code value.
@@ -105,9 +120,14 @@ type Timestamp struct {
 	I uint32
 }
 
-// Equal compaes tp to tp2 and returns true is the are equal.
+// Equal compares tp to tp2 and returns true is the are equal.
 func (tp Timestamp) Equal(tp2 Timestamp) bool {
 	return tp.T == tp2.T && tp.I == tp2.I
+}
+
+// IsZero returns if tp is the zero Timestamp
+func (tp Timestamp) IsZero() bool {
+	return tp.T == 0 && tp.I == 0
 }
 
 // CompareTimestamp returns an integer comparing two Timestamps, where T is compared first, followed by I.

--- a/vendor/go.mongodb.org/mongo-driver/mongo/bulk_write.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/bulk_write.go
@@ -177,7 +177,7 @@ func (bw *bulkWrite) runInsert(ctx context.Context, batch bulkWriteBatch) (opera
 		Session(bw.session).WriteConcern(bw.writeConcern).CommandMonitor(bw.collection.client.monitor).
 		ServerSelector(bw.selector).ClusterClock(bw.collection.client.clock).
 		Database(bw.collection.db.name).Collection(bw.collection.name).
-		Deployment(bw.collection.client.topology)
+		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.crypt)
 	if bw.bypassDocumentValidation != nil && *bw.bypassDocumentValidation {
 		op = op.BypassDocumentValidation(*bw.bypassDocumentValidation)
 	}
@@ -223,7 +223,7 @@ func (bw *bulkWrite) runDelete(ctx context.Context, batch bulkWriteBatch) (opera
 		Session(bw.session).WriteConcern(bw.writeConcern).CommandMonitor(bw.collection.client.monitor).
 		ServerSelector(bw.selector).ClusterClock(bw.collection.client.clock).
 		Database(bw.collection.db.name).Collection(bw.collection.name).
-		Deployment(bw.collection.client.topology)
+		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.crypt)
 	if bw.ordered != nil {
 		op = op.Ordered(*bw.ordered)
 	}
@@ -287,7 +287,7 @@ func (bw *bulkWrite) runUpdate(ctx context.Context, batch bulkWriteBatch) (opera
 		Session(bw.session).WriteConcern(bw.writeConcern).CommandMonitor(bw.collection.client.monitor).
 		ServerSelector(bw.selector).ClusterClock(bw.collection.client.clock).
 		Database(bw.collection.db.name).Collection(bw.collection.name).
-		Deployment(bw.collection.client.topology)
+		Deployment(bw.collection.client.deployment).Crypt(bw.collection.client.crypt)
 	if bw.ordered != nil {
 		op = op.Ordered(*bw.ordered)
 	}

--- a/vendor/go.mongodb.org/mongo-driver/mongo/change_stream.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/change_stream.go
@@ -87,8 +87,8 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 	}
 
 	cs.sess = sessionFromContext(ctx)
-	if cs.sess == nil && cs.client.topology.SessionPool != nil {
-		cs.sess, cs.err = session.NewClientSession(cs.client.topology.SessionPool, cs.client.id, session.Implicit)
+	if cs.sess == nil && cs.client.sessionPool != nil {
+		cs.sess, cs.err = session.NewClientSession(cs.client.sessionPool, cs.client.id, session.Implicit)
 		if cs.err != nil {
 			return nil, cs.Err()
 		}
@@ -100,7 +100,7 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 
 	cs.aggregate = operation.NewAggregate(nil).
 		ReadPreference(config.readPreference).ReadConcern(config.readConcern).
-		Deployment(cs.client.topology).ClusterClock(cs.client.clock).
+		Deployment(cs.client.deployment).ClusterClock(cs.client.clock).
 		CommandMonitor(cs.client.monitor).Session(cs.sess).ServerSelector(cs.selector).Retry(driver.RetryNone)
 
 	if cs.options.Collation != nil {
@@ -161,12 +161,17 @@ func newChangeStream(ctx context.Context, config changeStreamConfig, pipeline in
 func (cs *ChangeStream) executeOperation(ctx context.Context, resuming bool) error {
 	var server driver.Server
 	var conn driver.Connection
-	if server, cs.err = cs.client.topology.SelectServer(ctx, cs.selector); cs.err != nil {
+	var err error
+
+	if server, cs.err = cs.client.deployment.SelectServer(ctx, cs.selector); cs.err != nil {
 		return cs.Err()
 	}
 	if conn, cs.err = server.Connection(ctx); cs.err != nil {
 		return cs.Err()
 	}
+
+	defer conn.Close()
+
 	cs.aggregate.Deployment(driver.SingleConnectionDeployment{
 		C: conn,
 	})
@@ -204,12 +209,15 @@ func (cs *ChangeStream) executeOperation(ctx context.Context, resuming bool) err
 				break
 			}
 
-			server, err := cs.client.topology.SelectServer(ctx, cs.selector)
+			server, err = cs.client.deployment.SelectServer(ctx, cs.selector)
 			if err != nil {
 				break
 			}
 
-			conn, err := server.Connection(ctx)
+			conn.Close()
+			conn, err = server.Connection(ctx)
+			defer conn.Close()
+
 			if err != nil {
 				break
 			}
@@ -433,7 +441,7 @@ func (cs *ChangeStream) Close(ctx context.Context) error {
 		ctx = context.Background()
 	}
 
-	closeImplicitSession(cs.sess)
+	defer closeImplicitSession(cs.sess)
 
 	if cs.cursor == nil {
 		return nil // cursor is already closed

--- a/vendor/go.mongodb.org/mongo-driver/mongo/client.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/client.go
@@ -9,6 +9,7 @@ package mongo
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -34,11 +35,15 @@ import (
 const defaultLocalThreshold = 15 * time.Millisecond
 const batchSize = 10000
 
+// keyVaultCollOpts specifies options used to communicate with the key vault collection
+var keyVaultCollOpts = options.Collection().SetReadConcern(readconcern.Majority()).
+	SetWriteConcern(writeconcern.New(writeconcern.WMajority()))
+
 // Client performs operations on a given topology.
 type Client struct {
 	id              uuid.UUID
 	topologyOptions []topology.Option
-	topology        *topology.Topology
+	deployment      driver.Deployment
 	connString      connstring.ConnString
 	localThreshold  time.Duration
 	retryWrites     bool
@@ -50,6 +55,13 @@ type Client struct {
 	registry        *bsoncodec.Registry
 	marshaller      BSONAppender
 	monitor         *event.CommandMonitor
+	sessionPool     *session.Pool
+
+	// client-side encryption fields
+	keyVaultClient *Client
+	keyVaultColl   *Collection
+	mongocryptd    *mcryptClient
+	crypt          *driver.Crypt
 }
 
 // Connect creates a new Client and then initializes it using the Connect method.
@@ -92,24 +104,46 @@ func NewClient(opts ...*options.ClientOptions) (*Client, error) {
 		return nil, err
 	}
 
-	client.topology, err = topology.New(client.topologyOptions...)
-	if err != nil {
-		return nil, replaceErrors(err)
+	if client.deployment == nil {
+		client.deployment, err = topology.New(client.topologyOptions...)
+		if err != nil {
+			return nil, replaceErrors(err)
+		}
 	}
-
 	return client, nil
 }
 
 // Connect initializes the Client by starting background monitoring goroutines.
 // This method must be called before a Client can be used.
 func (c *Client) Connect(ctx context.Context) error {
-	err := c.topology.Connect()
-	if err != nil {
-		return replaceErrors(err)
+	if connector, ok := c.deployment.(driver.Connector); ok {
+		err := connector.Connect()
+		if err != nil {
+			return replaceErrors(err)
+		}
 	}
 
-	return nil
+	if c.mongocryptd != nil {
+		if err := c.mongocryptd.connect(ctx); err != nil {
+			return err
+		}
+	}
+	if c.keyVaultClient != nil {
+		if err := c.keyVaultClient.Connect(ctx); err != nil {
+			return err
+		}
+	}
 
+	var updateChan <-chan description.Topology
+	if subscriber, ok := c.deployment.(driver.Subscriber); ok {
+		sub, err := subscriber.Subscribe()
+		if err != nil {
+			return replaceErrors(err)
+		}
+		updateChan = sub.Updates
+	}
+	c.sessionPool = session.NewPool(updateChan)
+	return nil
 }
 
 // Disconnect closes sockets to the topology referenced by this Client. It will
@@ -126,7 +160,24 @@ func (c *Client) Disconnect(ctx context.Context) error {
 	}
 
 	c.endSessions(ctx)
-	return replaceErrors(c.topology.Disconnect(ctx))
+	if c.mongocryptd != nil {
+		if err := c.mongocryptd.disconnect(ctx); err != nil {
+			return err
+		}
+	}
+	if c.keyVaultClient != nil {
+		if err := c.keyVaultClient.Disconnect(ctx); err != nil {
+			return err
+		}
+	}
+	if c.crypt != nil {
+		c.crypt.Close()
+	}
+
+	if disconnector, ok := c.deployment.(driver.Disconnector); ok {
+		return replaceErrors(disconnector.Disconnect(ctx))
+	}
+	return nil
 }
 
 // Ping verifies that the client can connect to the topology.
@@ -144,14 +195,14 @@ func (c *Client) Ping(ctx context.Context, rp *readpref.ReadPref) error {
 	db := c.Database("admin")
 	res := db.RunCommand(ctx, bson.D{
 		{"ping", 1},
-	})
+	}, options.RunCmd().SetReadPreference(rp))
 
 	return replaceErrors(res.Err())
 }
 
 // StartSession starts a new session.
 func (c *Client) StartSession(opts ...*options.SessionOptions) (Session, error) {
-	if c.topology.SessionPool == nil {
+	if c.sessionPool == nil {
 		return nil, ErrClientDisconnected
 	}
 
@@ -177,7 +228,7 @@ func (c *Client) StartSession(opts ...*options.SessionOptions) (Session, error) 
 		coreOpts.DefaultMaxCommitTime = sopts.DefaultMaxCommitTime
 	}
 
-	sess, err := session.NewClientSession(c.topology.SessionPool, c.id, session.Explicit, coreOpts)
+	sess, err := session.NewClientSession(c.sessionPool, c.id, session.Explicit, coreOpts)
 	if err != nil {
 		return nil, replaceErrors(err)
 	}
@@ -188,16 +239,16 @@ func (c *Client) StartSession(opts ...*options.SessionOptions) (Session, error) 
 	return &sessionImpl{
 		clientSession: sess,
 		client:        c,
-		topo:          c.topology,
+		deployment:    c.deployment,
 	}, nil
 }
 
 func (c *Client) endSessions(ctx context.Context) {
-	if c.topology.SessionPool == nil {
+	if c.sessionPool == nil {
 		return
 	}
 
-	ids := c.topology.SessionPool.IDSlice()
+	ids := c.sessionPool.IDSlice()
 	idx, idArray := bsoncore.AppendArrayStart(nil)
 	for i, id := range ids {
 		idDoc, _ := id.MarshalBSON()
@@ -205,8 +256,9 @@ func (c *Client) endSessions(ctx context.Context) {
 	}
 	idArray, _ = bsoncore.AppendArrayEnd(idArray, idx)
 
-	op := operation.NewEndSessions(idArray).ClusterClock(c.clock).Deployment(c.topology).
-		ServerSelector(description.ReadPrefSelector(readpref.PrimaryPreferred())).CommandMonitor(c.monitor).Database("admin")
+	op := operation.NewEndSessions(idArray).ClusterClock(c.clock).Deployment(c.deployment).
+		ServerSelector(description.ReadPrefSelector(readpref.PrimaryPreferred())).CommandMonitor(c.monitor).
+		Database("admin").Crypt(c.crypt)
 
 	idx, idArray = bsoncore.AppendArrayStart(nil)
 	totalNumIDs := len(ids)
@@ -442,6 +494,12 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 	if opts.WriteConcern != nil {
 		c.writeConcern = opts.WriteConcern
 	}
+	// AutoEncryptionOptions
+	if opts.AutoEncryptionOptions != nil {
+		if err := c.configureAutoEncryption(opts.AutoEncryptionOptions); err != nil {
+			return err
+		}
+	}
 
 	// ClusterClock
 	c.clock = new(session.ClusterClock)
@@ -455,7 +513,82 @@ func (c *Client) configure(opts *options.ClientOptions) error {
 		func(...topology.ServerOption) []topology.ServerOption { return serverOpts },
 	))
 
+	// Deployment
+	if opts.Deployment != nil {
+		if len(serverOpts) > 2 || len(topologyOpts) > 1 {
+			return errors.New("cannot specify topology or server options with a deployment")
+		}
+		c.deployment = opts.Deployment
+	}
+
 	return nil
+}
+
+func (c *Client) configureAutoEncryption(opts *options.AutoEncryptionOptions) error {
+	if err := c.configureKeyVault(opts); err != nil {
+		return err
+	}
+	if err := c.configureMongocryptd(opts); err != nil {
+		return err
+	}
+	return c.configureCrypt(opts)
+}
+
+func (c *Client) configureKeyVault(opts *options.AutoEncryptionOptions) error {
+	// parse key vault options and create new client if necessary
+	if opts.KeyVaultClientOptions != nil {
+		var err error
+		c.keyVaultClient, err = NewClient(opts.KeyVaultClientOptions)
+		if err != nil {
+			return err
+		}
+	}
+
+	dbName, collName := splitNamespace(opts.KeyVaultNamespace)
+	client := c.keyVaultClient
+	if client == nil {
+		client = c
+	}
+	c.keyVaultColl = client.Database(dbName).Collection(collName, keyVaultCollOpts)
+	return nil
+}
+
+func (c *Client) configureMongocryptd(opts *options.AutoEncryptionOptions) error {
+	var err error
+	c.mongocryptd, err = newMcryptClient(opts.ExtraOptions)
+	return err
+}
+
+func (c *Client) configureCrypt(opts *options.AutoEncryptionOptions) error {
+	// convert schemas in SchemaMap to bsoncore documents
+	cryptSchemaMap := make(map[string]bsoncore.Document)
+	for k, v := range opts.SchemaMap {
+		schema, err := transformBsoncoreDocument(c.registry, v)
+		if err != nil {
+			return err
+		}
+		cryptSchemaMap[k] = schema
+	}
+
+	// configure options
+	var bypass bool
+	if opts.BypassAutoEncryption != nil {
+		bypass = *opts.BypassAutoEncryption
+	}
+	kr := keyRetriever{coll: c.keyVaultColl}
+	cir := collInfoRetriever{client: c}
+	cryptOpts := &driver.CryptOptions{
+		CollInfoFn:           cir.cryptCollInfo,
+		KeyFn:                kr.cryptKeys,
+		MarkFn:               c.mongocryptd.markCommand,
+		KmsProviders:         opts.KmsProviders,
+		BypassAutoEncryption: bypass,
+		SchemaMap:            cryptSchemaMap,
+	}
+
+	var err error
+	c.crypt, err = driver.NewCrypt(cryptOpts)
+	return err
 }
 
 // validSession returns an error if the session doesn't belong to the client
@@ -480,8 +613,8 @@ func (c *Client) ListDatabases(ctx context.Context, filter interface{}, opts ...
 	sess := sessionFromContext(ctx)
 
 	err := c.validSession(sess)
-	if sess == nil && c.topology.SessionPool != nil {
-		sess, err = session.NewClientSession(c.topology.SessionPool, c.id, session.Implicit)
+	if sess == nil && c.sessionPool != nil {
+		sess, err = session.NewClientSession(c.sessionPool, c.id, session.Implicit)
 		if err != nil {
 			return ListDatabasesResult{}, err
 		}
@@ -498,15 +631,16 @@ func (c *Client) ListDatabases(ctx context.Context, filter interface{}, opts ...
 		return ListDatabasesResult{}, err
 	}
 
-	selector := makePinnedSelector(sess, description.CompositeSelector([]description.ServerSelector{
+	selector := description.CompositeSelector([]description.ServerSelector{
 		description.ReadPrefSelector(readpref.Primary()),
 		description.LatencySelector(c.localThreshold),
-	}))
+	})
+	selector = makeReadPrefSelector(sess, selector, c.localThreshold)
 
 	ldo := options.MergeListDatabasesOptions(opts...)
 	op := operation.NewListDatabases(filterDoc).
 		Session(sess).ReadPreference(c.readPreference).CommandMonitor(c.monitor).
-		ServerSelector(selector).ClusterClock(c.clock).Database("admin").Deployment(c.topology)
+		ServerSelector(selector).ClusterClock(c.clock).Database("admin").Deployment(c.deployment).Crypt(c.crypt)
 	if ldo.NameOnly != nil {
 		op = op.NameOnly(*ldo.NameOnly)
 	}
@@ -594,7 +728,7 @@ func (c *Client) UseSessionWithOptions(ctx context.Context, opts *options.Sessio
 // The client must have read concern majority or no read concern for a change stream to be created successfully.
 func (c *Client) Watch(ctx context.Context, pipeline interface{},
 	opts ...*options.ChangeStreamOptions) (*ChangeStream, error) {
-	if c.topology.SessionPool == nil {
+	if c.sessionPool == nil {
 		return nil, ErrClientDisconnected
 	}
 

--- a/vendor/go.mongodb.org/mongo-driver/mongo/client_encryption.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/client_encryption.go
@@ -1,0 +1,137 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mongo
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	cryptOpts "go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options"
+)
+
+// ClientEncryption is used to create data keys and explicitly encrypt and decrypt BSON values.
+// This type is in beta. The API does not have any stability guarantees and backwards-breaking changes may be made
+// before the final release.
+type ClientEncryption struct {
+	crypt          *driver.Crypt
+	keyVaultClient *Client
+	keyVaultColl   *Collection
+}
+
+// NewClientEncryption creates a new ClientEncryption instance configured with the given options.
+func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncryptionOptions) (*ClientEncryption, error) {
+	if keyVaultClient == nil {
+		return nil, errors.New("keyVaultClient must not be nil")
+	}
+
+	ce := &ClientEncryption{
+		keyVaultClient: keyVaultClient,
+	}
+	ceo := options.MergeClientEncryptionOptions(opts...)
+
+	// create keyVaultColl
+	db, coll := splitNamespace(ceo.KeyVaultNamespace)
+	ce.keyVaultColl = ce.keyVaultClient.Database(db).Collection(coll, keyVaultCollOpts)
+
+	// create Crypt
+	var err error
+	kr := keyRetriever{coll: ce.keyVaultColl}
+	cir := collInfoRetriever{client: ce.keyVaultClient}
+	ce.crypt, err = driver.NewCrypt(&driver.CryptOptions{
+		KeyFn:        kr.cryptKeys,
+		CollInfoFn:   cir.cryptCollInfo,
+		KmsProviders: ceo.KmsProviders,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ce, nil
+}
+
+// CreateDataKey creates a new key document and inserts it into the key vault collection. Returns the _id of the
+// created document.
+func (ce *ClientEncryption) CreateDataKey(ctx context.Context, kmsProvider string, opts ...*options.DataKeyOptions) (primitive.Binary, error) {
+	// translate opts to cryptOpts.DataKeyOptions
+	dko := options.MergeDataKeyOptions(opts...)
+	co := cryptOpts.DataKey().SetKeyAltNames(dko.KeyAltNames)
+	if dko.MasterKey != nil {
+		keyDoc, err := transformBsoncoreDocument(ce.keyVaultClient.registry, dko.MasterKey)
+		if err != nil {
+			return primitive.Binary{}, err
+		}
+
+		co.SetMasterKey(keyDoc)
+	}
+
+	// create data key document
+	dataKeyDoc, err := ce.crypt.CreateDataKey(ctx, kmsProvider, co)
+	if err != nil {
+		return primitive.Binary{}, err
+	}
+
+	// insert key into key vault
+	_, err = ce.keyVaultColl.InsertOne(ctx, dataKeyDoc)
+	if err != nil {
+		return primitive.Binary{}, err
+	}
+
+	subtype, data := bson.Raw(dataKeyDoc).Lookup("_id").Binary()
+	return primitive.Binary{Subtype: subtype, Data: data}, nil
+}
+
+// Encrypt encrypts a BSON value with the given key and algorithm. Returns an encrypted value (BSON binary of subtype 6).
+func (ce *ClientEncryption) Encrypt(ctx context.Context, val bson.RawValue, opts ...*options.EncryptOptions) (primitive.Binary, error) {
+	eo := options.MergeEncryptOptions(opts...)
+	transformed := cryptOpts.ExplicitEncryption()
+	if eo.KeyID != nil {
+		transformed.SetKeyID(*eo.KeyID)
+	}
+	if eo.KeyAltName != nil {
+		transformed.SetKeyAltName(*eo.KeyAltName)
+	}
+	transformed.SetAlgorithm(eo.Algorithm)
+
+	subtype, data, err := ce.crypt.EncryptExplicit(ctx, bsoncore.Value{Type: val.Type, Data: val.Value}, transformed)
+	if err != nil {
+		return primitive.Binary{}, err
+	}
+	return primitive.Binary{Subtype: subtype, Data: data}, nil
+}
+
+// Decrypt decrypts an encrypted value (BSON binary of subtype 6) and returns the original BSON value.
+func (ce *ClientEncryption) Decrypt(ctx context.Context, val primitive.Binary) (bson.RawValue, error) {
+	decrypted, err := ce.crypt.DecryptExplicit(ctx, val.Subtype, val.Data)
+	if err != nil {
+		return bson.RawValue{}, err
+	}
+
+	return bson.RawValue{Type: decrypted.Type, Value: decrypted.Data}, nil
+}
+
+// Close cleans up any resources associated with the ClientEncryption instance. This includes disconnecting the
+// key-vault Client instance.
+func (ce *ClientEncryption) Close(ctx context.Context) error {
+	ce.crypt.Close()
+	return ce.keyVaultClient.Disconnect(ctx)
+}
+
+// splitNamespace takes a namespace in the form "database.collection" and returns (database name, collection name)
+func splitNamespace(ns string) (string, string) {
+	firstDot := strings.Index(ns, ".")
+	if firstDot == -1 {
+		return "", ns
+	}
+
+	return ns[:firstDot], ns[firstDot+1:]
+}

--- a/vendor/go.mongodb.org/mongo-driver/mongo/crypt_retrievers.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/crypt_retrievers.go
@@ -1,0 +1,59 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mongo
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+// keyRetriever gets keys from the key vault collection.
+type keyRetriever struct {
+	coll *Collection
+}
+
+func (kr *keyRetriever) cryptKeys(ctx context.Context, filter bsoncore.Document) ([]bsoncore.Document, error) {
+	cursor, err := kr.coll.Find(ctx, filter)
+	if err != nil {
+		return nil, EncryptionKeyVaultError{Wrapped: err}
+	}
+	defer cursor.Close(ctx)
+
+	var results []bsoncore.Document
+	for cursor.Next(ctx) {
+		cur := make([]byte, len(cursor.Current))
+		copy(cur, cursor.Current)
+		results = append(results, cur)
+	}
+	if err = cursor.Err(); err != nil {
+		return nil, EncryptionKeyVaultError{Wrapped: err}
+	}
+
+	return results, nil
+}
+
+// collInfoRetriever gets info for collections from a database.
+type collInfoRetriever struct {
+	client *Client
+}
+
+func (cir *collInfoRetriever) cryptCollInfo(ctx context.Context, db string, filter bsoncore.Document) (bsoncore.Document, error) {
+	cursor, err := cir.client.Database(db).ListCollections(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	if !cursor.Next(ctx) {
+		return nil, cursor.Err()
+	}
+
+	res := make([]byte, len(cursor.Current))
+	copy(res, cursor.Current)
+	return res, nil
+}

--- a/vendor/go.mongodb.org/mongo-driver/mongo/cursor.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/cursor.go
@@ -156,6 +156,7 @@ func (c *Cursor) Close(ctx context.Context) error {
 // All iterates the cursor and decodes each document into results.
 // The results parameter must be a pointer to a slice. The slice pointed to by results will be completely overwritten.
 // If the cursor has been iterated, any previously iterated documents will not be included in results.
+// The cursor will be closed after the method has returned.
 func (c *Cursor) All(ctx context.Context, results interface{}) error {
 	resultsVal := reflect.ValueOf(results)
 	if resultsVal.Kind() != reflect.Ptr {
@@ -166,6 +167,8 @@ func (c *Cursor) All(ctx context.Context, results interface{}) error {
 	elementType := sliceVal.Type().Elem()
 	var index int
 	var err error
+
+	defer c.Close(ctx)
 
 	batch := c.batch // exhaust the current batch before iterating the batch cursor
 	for {

--- a/vendor/go.mongodb.org/mongo-driver/mongo/database.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/database.go
@@ -120,9 +120,9 @@ func (db *Database) Aggregate(ctx context.Context, pipeline interface{},
 func (db *Database) processRunCommand(ctx context.Context, cmd interface{},
 	opts ...*options.RunCmdOptions) (*operation.Command, *session.Client, error) {
 	sess := sessionFromContext(ctx)
-	if sess == nil && db.client.topology.SessionPool != nil {
+	if sess == nil && db.client.sessionPool != nil {
 		var err error
-		sess, err = session.NewClientSession(db.client.topology.SessionPool, db.client.id, session.Implicit)
+		sess, err = session.NewClientSession(db.client.sessionPool, db.client.id, session.Implicit)
 		if err != nil {
 			return nil, sess, err
 		}
@@ -153,7 +153,7 @@ func (db *Database) processRunCommand(ctx context.Context, cmd interface{},
 	return operation.NewCommand(runCmdDoc).
 		Session(sess).CommandMonitor(db.client.monitor).
 		ServerSelector(readSelect).ClusterClock(db.client.clock).
-		Database(db.name).Deployment(db.client.topology).ReadConcern(db.readConcern), sess, nil
+		Database(db.name).Deployment(db.client.deployment).ReadConcern(db.readConcern).Crypt(db.client.crypt), sess, nil
 }
 
 // RunCommand runs a command on the database. A user can supply a custom
@@ -211,8 +211,9 @@ func (db *Database) Drop(ctx context.Context) error {
 	}
 
 	sess := sessionFromContext(ctx)
-	if sess == nil && db.client.topology.SessionPool != nil {
-		sess, err := session.NewClientSession(db.client.topology.SessionPool, db.client.id, session.Implicit)
+	if sess == nil && db.client.sessionPool != nil {
+		var err error
+		sess, err = session.NewClientSession(db.client.sessionPool, db.client.id, session.Implicit)
 		if err != nil {
 			return err
 		}
@@ -237,7 +238,7 @@ func (db *Database) Drop(ctx context.Context) error {
 	op := operation.NewDropDatabase().
 		Session(sess).WriteConcern(wc).CommandMonitor(db.client.monitor).
 		ServerSelector(selector).ClusterClock(db.client.clock).
-		Database(db.name).Deployment(db.client.topology)
+		Database(db.name).Deployment(db.client.deployment).Crypt(db.client.crypt)
 
 	err = op.Execute(ctx)
 
@@ -260,8 +261,8 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 	}
 
 	sess := sessionFromContext(ctx)
-	if sess == nil && db.client.topology.SessionPool != nil {
-		sess, err = session.NewClientSession(db.client.topology.SessionPool, db.client.id, session.Implicit)
+	if sess == nil && db.client.sessionPool != nil {
+		sess, err = session.NewClientSession(db.client.sessionPool, db.client.id, session.Implicit)
 		if err != nil {
 			return nil, err
 		}
@@ -273,13 +274,17 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 		return nil, err
 	}
 
-	selector := makePinnedSelector(sess, db.readSelector)
+	selector := description.CompositeSelector([]description.ServerSelector{
+		description.ReadPrefSelector(readpref.Primary()),
+		description.LatencySelector(db.client.localThreshold),
+	})
+	selector = makeReadPrefSelector(sess, selector, db.client.localThreshold)
 
 	lco := options.MergeListCollectionsOptions(opts...)
 	op := operation.NewListCollections(filterDoc).
 		Session(sess).ReadPreference(db.readPreference).CommandMonitor(db.client.monitor).
 		ServerSelector(selector).ClusterClock(db.client.clock).
-		Database(db.name).Deployment(db.client.topology)
+		Database(db.name).Deployment(db.client.deployment).Crypt(db.client.crypt)
 	if lco.NameOnly != nil {
 		op = op.NameOnly(*lco.NameOnly)
 	}
@@ -295,7 +300,7 @@ func (db *Database) ListCollections(ctx context.Context, filter interface{}, opt
 		return nil, replaceErrors(err)
 	}
 
-	bc, err := op.Result(driver.CursorOptions{})
+	bc, err := op.Result(driver.CursorOptions{Crypt: db.client.crypt})
 	if err != nil {
 		closeImplicitSession(sess)
 		return nil, replaceErrors(err)

--- a/vendor/go.mongodb.org/mongo-driver/mongo/doc.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/doc.go
@@ -77,5 +77,43 @@
 // https://github.com/golang/go/issues/10622. If you receive an error with the message "cannot
 // unmarshal DNS message" while running an operation, we suggest you use a different DNS server.
 //
+// Client Side Encryption
+//
+// Client-side encryption is a new feature in MongoDB 4.2 that allows specific data fields to be encrypted.
+//
+// Important: This feature is beta. The API for both automatic and explicit encryption/decryption does not have any
+// stability guarantees and backwards-breaking changes may be made before the final release.
+//
+// Note: Auto encryption is an enterprise-only feature.
+//
+// The libmongocrypt C library is required when using client-side encryption. To install libmongocrypt, do the following:
+//
+//    // run the clone command in an empty folder because the compile script will create new directories.
+//    git clone https://github.com/mongodb/libmongocrypt
+//    ./libmongocrypt/.evergreen/compile.sh
+//
+//    // Linux/Darwin: (this requires pkg-config to be installed on the system)
+//    Add <installation_dir>/install/libmongocrypt/lib/pkgconfig:<installation_dir>/install/mongo-c-driver/lib/pkgconfig to PKG_CONFIG_PATH.
+//    Add <installation_dir>/install/libmongocrypt/lib to LD_LIBRARY_PATH
+//
+//    // Windows:
+//    mkdir -p c:/libmongocrypt/include
+//    mkdir -p c:/libmongocrypt/bin
+//    cp ./install/libmongocrypt/lib/mongocrypt.dll c:/libmongocrypt/bin
+//    cp ./install/libmongocrypt/include/mongocrypt/*.h c:/libmongocrypt/include
+//    // add c:/libmongocrypt/bin to PATH
+//
+// libmongocrypt communicates with the mongocryptd process for automatic encryption. This process can be started manually
+// or auto-spawned by the driver itself. To enable auto-spawning, ensure the process binary is on the PATH. To start it
+// manually, use AutoEncryptionOptions:
+//
+//    aeo := options.AutoEncryption()
+//    mongocryptdOpts := map[string]interface{}{
+//        "mongocryptdBypassSpawn": true,
+//    }
+//    aeo.SetExtraOptions(mongocryptdOpts)
+// To specify a process URI for mongocryptd, the "mongocryptdURI" option can be passed in the ExtraOptions map as well.
+// More information about mongocryptd will soon be available from the official documentation.
+//
 // [1] See https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
 package mongo

--- a/vendor/go.mongodb.org/mongo-driver/mongo/errors.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/errors.go
@@ -13,6 +13,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 )
 
@@ -54,8 +55,43 @@ func replaceErrors(err error) error {
 
 		return ce
 	}
+	if me, ok := err.(mongocrypt.Error); ok {
+		return MongocryptError{Code: me.Code, Message: me.Message}
+	}
 
 	return err
+}
+
+// MongocryptError is an error that occurs when executing an operation in mongocrypt.
+type MongocryptError struct {
+	Code    int32
+	Message string
+}
+
+// Error implements the error interface.
+func (m MongocryptError) Error() string {
+	return fmt.Sprintf("mongocrypt error %d: %v", m.Code, m.Message)
+}
+
+// EncryptionKeyVaultError represents an error while communicating with the key vault collection during client side
+// encryption.
+type EncryptionKeyVaultError struct {
+	Wrapped error
+}
+
+// Error implements the error interface.
+func (ekve EncryptionKeyVaultError) Error() string {
+	return fmt.Sprintf("key vault communication error: %v", ekve.Wrapped)
+}
+
+// MongocryptdError represents an error while communicating with mongocryptd.
+type MongocryptdError struct {
+	Wrapped error
+}
+
+// Error implements the error interface.
+func (e MongocryptdError) Error() string {
+	return fmt.Sprintf("mongocryptd communication error: %v", e.Wrapped)
 }
 
 // CommandError represents an error in execution of a command against the database.

--- a/vendor/go.mongodb.org/mongo-driver/mongo/mongocryptd.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/mongocryptd.go
@@ -1,0 +1,137 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mongo
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readconcern"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+const (
+	defaultServerSelectionTimeout = 1 * time.Second
+	defaultURI                    = "mongodb://localhost:27020"
+	defaultPath                   = "mongocryptd"
+	serverSelectionTimeoutStr     = "server selection error"
+)
+
+var defaultTimeoutArgs = []string{"--idleShutdownTimeoutSecs=60"}
+var databaseOpts = options.Database().SetReadConcern(readconcern.New()).SetReadPreference(readpref.Primary())
+
+type mcryptClient struct {
+	bypassSpawn bool
+	client      *Client
+	path        string
+	spawnArgs   []string
+}
+
+func newMcryptClient(opts map[string]interface{}) (*mcryptClient, error) {
+	// create mcryptClient instance and spawn process if necessary
+	mc := &mcryptClient{}
+	if bypass, ok := opts["mongocryptdBypassSpawn"]; ok {
+		mc.bypassSpawn = bypass.(bool)
+	}
+
+	if !mc.bypassSpawn {
+		mc.path, mc.spawnArgs = createSpawnArgs(opts)
+		if err := mc.spawnProcess(); err != nil {
+			return nil, err
+		}
+	}
+
+	// get connection string
+	uri := defaultURI
+	if u, ok := opts["mongocryptdURI"]; ok {
+		uri = u.(string)
+	}
+
+	// create client
+	client, err := NewClient(options.Client().ApplyURI(uri).SetServerSelectionTimeout(defaultServerSelectionTimeout))
+	if err != nil {
+		return nil, err
+	}
+	mc.client = client
+
+	return mc, nil
+}
+
+// markCommand executes the given command on mongocryptd.
+func (mc *mcryptClient) markCommand(ctx context.Context, dbName string, cmd bsoncore.Document) (bsoncore.Document, error) {
+	db := mc.client.Database(dbName, databaseOpts)
+
+	res, err := db.RunCommand(ctx, cmd).DecodeBytes()
+	// propagate original result
+	if err == nil {
+		return bsoncore.Document(res), nil
+	}
+	// wrap original error
+	if mc.bypassSpawn || !strings.Contains(err.Error(), serverSelectionTimeoutStr) {
+		return nil, MongocryptdError{Wrapped: err}
+	}
+
+	// re-spawn and retry
+	if err = mc.spawnProcess(); err != nil {
+		return nil, err
+	}
+	res, err = db.RunCommand(ctx, cmd).DecodeBytes()
+	if err != nil {
+		return nil, MongocryptdError{Wrapped: err}
+	}
+	return bsoncore.Document(res), nil
+}
+
+// connect connects the underlying Client instance. This must be called before performing any mark operations.
+func (mc *mcryptClient) connect(ctx context.Context) error {
+	return mc.client.Connect(ctx)
+}
+
+// disconnect disconnects the underlying Client instance. This should be called after all operations have completed.
+func (mc *mcryptClient) disconnect(ctx context.Context) error {
+	return mc.client.Disconnect(ctx)
+}
+
+func (mc *mcryptClient) spawnProcess() error {
+	return exec.Command(mc.path, mc.spawnArgs...).Start()
+}
+
+// createSpawnArgs creates arguments to spawn mcryptClient. It returns the path and a slice of arguments.
+func createSpawnArgs(opts map[string]interface{}) (string, []string) {
+	var spawnArgs []string
+
+	// get command path
+	path := defaultPath
+	if p, ok := opts["mongocryptdPath"]; ok {
+		path = p.(string)
+	}
+
+	// add specified options
+	if sa, ok := opts["mongocryptdSpawnArgs"]; ok {
+		spawnArgs = append(spawnArgs, sa.([]string)...)
+	}
+
+	// add timeout options if necessary
+	var foundTimeout bool
+	for _, arg := range spawnArgs {
+		// need to use HasPrefix instead of doing an exact equality check because both
+		// mongocryptd supports both [--idleShutdownTimeoutSecs, 0] and [--idleShutdownTimeoutSecs=0]
+		if strings.HasPrefix(arg, "--idleShutdownTimeoutSecs") {
+			foundTimeout = true
+			break
+		}
+	}
+	if !foundTimeout {
+		spawnArgs = append(spawnArgs, defaultTimeoutArgs...)
+	}
+
+	return path, spawnArgs
+}

--- a/vendor/go.mongodb.org/mongo-driver/mongo/options/autoencryptionoptions.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/options/autoencryptionoptions.go
@@ -1,0 +1,112 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package options
+
+// AutoEncryptionOptions represents options used to configure auto encryption/decryption behavior for a mongo.Client
+// instance.
+//
+// Automatic encryption is an enterprise only feature that only applies to operations on a collection. Automatic
+// encryption is not supported for operations on a database or view, and operations that are not bypassed will result
+// in error. Too bypass automatic encryption for all operations, set BypassAutoEncryption=true.
+//
+// Auto encryption requires the authenticated user to have the listCollections privilege action.
+//
+// If automatic encryption fails on an operation, use a MongoClient configured with bypassAutoEncryption=true and use
+// ClientEncryption.encrypt() to manually encrypt values.
+//
+// Enabling Client Side Encryption reduces the maximum document and message size (using a maxBsonObjectSize of 2MiB and
+// maxMessageSizeBytes of 6MB) and may have a negative performance impact.
+//
+// This type is in beta. The API does not have any stability guarantees and backwards-breaking changes may be made
+// before the final release.
+type AutoEncryptionOptions struct {
+	KeyVaultClientOptions *ClientOptions
+	KeyVaultNamespace     string
+	KmsProviders          map[string]map[string]interface{}
+	SchemaMap             map[string]interface{}
+	BypassAutoEncryption  *bool
+	ExtraOptions          map[string]interface{}
+}
+
+// AutoEncryption creates a new AutoEncryptionOptions configured with default values.
+func AutoEncryption() *AutoEncryptionOptions {
+	return &AutoEncryptionOptions{}
+}
+
+// SetKeyVaultClientOptions specifies options for the client used to communicate with the key vault collection. If this is
+// not set, the client used to do encryption will be re-used for key vault communication.
+func (a *AutoEncryptionOptions) SetKeyVaultClientOptions(opts *ClientOptions) *AutoEncryptionOptions {
+	a.KeyVaultClientOptions = opts
+	return a
+}
+
+// SetKeyVaultNamespace specifies the namespace of the key vault collection. This is required.
+func (a *AutoEncryptionOptions) SetKeyVaultNamespace(ns string) *AutoEncryptionOptions {
+	a.KeyVaultNamespace = ns
+	return a
+}
+
+// SetKmsProviders specifies options for KMS providers. This is required.
+func (a *AutoEncryptionOptions) SetKmsProviders(providers map[string]map[string]interface{}) *AutoEncryptionOptions {
+	a.KmsProviders = providers
+	return a
+}
+
+// SetSchemaMap specifies a map from namespace to local schema document. Schemas supplied in the schemaMap only apply
+// to configuring automatic encryption for client side encryption. Other validation rules in the JSON schema will not
+// be enforced by the driver and will result in an error.
+//
+// Supplying a schemaMap provides more security than relying on JSON Schemas obtained from the server. It protects
+// against a malicious server advertising a false JSON Schema, which could trick the client into sending unencrypted
+// data that should be encrypted.
+func (a *AutoEncryptionOptions) SetSchemaMap(schemaMap map[string]interface{}) *AutoEncryptionOptions {
+	a.SchemaMap = schemaMap
+	return a
+}
+
+// SetBypassAutoEncryption specifies whether or not auto encryption should be done.
+func (a *AutoEncryptionOptions) SetBypassAutoEncryption(bypass bool) *AutoEncryptionOptions {
+	a.BypassAutoEncryption = &bypass
+	return a
+}
+
+// SetExtraOptions specifies a map of options to configure the mongocryptd process.
+func (a *AutoEncryptionOptions) SetExtraOptions(extraOpts map[string]interface{}) *AutoEncryptionOptions {
+	a.ExtraOptions = extraOpts
+	return a
+}
+
+// MergeAutoEncryptionOptions combines the argued AutoEncryptionOptions in a last-one wins fashion.
+func MergeAutoEncryptionOptions(opts ...*AutoEncryptionOptions) *AutoEncryptionOptions {
+	aeo := AutoEncryption()
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+
+		if opt.KeyVaultClientOptions != nil {
+			aeo.KeyVaultClientOptions = opt.KeyVaultClientOptions
+		}
+		if opt.KeyVaultNamespace != "" {
+			aeo.KeyVaultNamespace = opt.KeyVaultNamespace
+		}
+		if opt.KmsProviders != nil {
+			aeo.KmsProviders = opt.KmsProviders
+		}
+		if opt.SchemaMap != nil {
+			aeo.SchemaMap = opt.SchemaMap
+		}
+		if opt.BypassAutoEncryption != nil {
+			aeo.BypassAutoEncryption = opt.BypassAutoEncryption
+		}
+		if opt.ExtraOptions != nil {
+			aeo.ExtraOptions = opt.ExtraOptions
+		}
+	}
+
+	return aeo
+}

--- a/vendor/go.mongodb.org/mongo-driver/mongo/options/clientencryptionoptions.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/options/clientencryptionoptions.go
@@ -1,0 +1,49 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package options
+
+// ClientEncryptionOptions represents all possible options used to configure a ClientEncryption instance.
+type ClientEncryptionOptions struct {
+	KeyVaultNamespace string
+	KmsProviders      map[string]map[string]interface{}
+}
+
+// ClientEncryption creates a new ClientEncryptionOptions instance.
+func ClientEncryption() *ClientEncryptionOptions {
+	return &ClientEncryptionOptions{}
+}
+
+// SetKeyVaultNamespace specifies the namespace of the key vault collection. This is required.
+func (c *ClientEncryptionOptions) SetKeyVaultNamespace(ns string) *ClientEncryptionOptions {
+	c.KeyVaultNamespace = ns
+	return c
+}
+
+// SetKmsProviders specifies options for KMS providers. This is required.
+func (c *ClientEncryptionOptions) SetKmsProviders(providers map[string]map[string]interface{}) *ClientEncryptionOptions {
+	c.KmsProviders = providers
+	return c
+}
+
+// MergeClientEncryptionOptions combines the argued ClientEncryptionOptions in a last-one wins fashion.
+func MergeClientEncryptionOptions(opts ...*ClientEncryptionOptions) *ClientEncryptionOptions {
+	ceo := ClientEncryption()
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+
+		if opt.KeyVaultNamespace != "" {
+			ceo.KeyVaultNamespace = opt.KeyVaultNamespace
+		}
+		if opt.KmsProviders != nil {
+			ceo.KmsProviders = opt.KmsProviders
+		}
+	}
+
+	return ceo
+}

--- a/vendor/go.mongodb.org/mongo-driver/mongo/options/clientoptions.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/options/clientoptions.go
@@ -25,6 +25,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"go.mongodb.org/mongo-driver/tag"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 )
 
@@ -90,12 +91,14 @@ type ClientOptions struct {
 	TLSConfig              *tls.Config
 	WriteConcern           *writeconcern.WriteConcern
 	ZlibLevel              *int
+	AutoEncryptionOptions  *AutoEncryptionOptions
 
 	err error
 
-	// Adds an option for internal use only and should not be set. This option is deprecated and is
-	// not part of the stability guarantee. It may be removed in the future.
+	// These options are for internal use only and should not be set. They are deprecated and are
+	// not part of the stability guarantee. They may be removed in the future.
 	AuthenticateToAnything *bool
+	Deployment             driver.Deployment
 }
 
 // Client creates a new ClientOptions instance.
@@ -411,6 +414,12 @@ func (c *ClientOptions) SetRetryWrites(b bool) *ClientOptions {
 	return c
 }
 
+// SetRetryReads specifies whether the client has retryable reads enabled.
+func (c *ClientOptions) SetRetryReads(b bool) *ClientOptions {
+	c.RetryReads = &b
+	return c
+}
+
 // SetServerSelectionTimeout specifies a timeout in milliseconds to block for server selection.
 func (c *ClientOptions) SetServerSelectionTimeout(d time.Duration) *ClientOptions {
 	c.ServerSelectionTimeout = &d
@@ -441,6 +450,12 @@ func (c *ClientOptions) SetWriteConcern(wc *writeconcern.WriteConcern) *ClientOp
 func (c *ClientOptions) SetZlibLevel(level int) *ClientOptions {
 	c.ZlibLevel = &level
 
+	return c
+}
+
+// SetAutoEncryptionOptions specifies options used to configure automatic encryption.
+func (c *ClientOptions) SetAutoEncryptionOptions(opts *AutoEncryptionOptions) *ClientOptions {
+	c.AutoEncryptionOptions = opts
 	return c
 }
 
@@ -532,6 +547,12 @@ func MergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 		}
 		if opt.ZlibLevel != nil {
 			c.ZlibLevel = opt.ZlibLevel
+		}
+		if opt.AutoEncryptionOptions != nil {
+			c.AutoEncryptionOptions = opt.AutoEncryptionOptions
+		}
+		if opt.Deployment != nil {
+			c.Deployment = opt.Deployment
 		}
 		if opt.err != nil {
 			c.err = opt.err

--- a/vendor/go.mongodb.org/mongo-driver/mongo/options/datakeyoptions.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/options/datakeyoptions.go
@@ -1,0 +1,55 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package options
+
+// DataKeyOptions represents all possible options used to create a new data key.
+type DataKeyOptions struct {
+	MasterKey   interface{}
+	KeyAltNames []string
+}
+
+// DataKey creates a new DataKeyOptions instance.
+func DataKey() *DataKeyOptions {
+	return &DataKeyOptions{}
+}
+
+// SetMasterKey specifies a KMS-specific key used to encrypt the new data key.
+//
+// If being used with the AWS KMS provider, this option is required and must be a document with the following format:
+// {region: string, key: string}.
+//
+// If being used with a local KMS provider, this option is not applicable and should not be specified.
+func (dk *DataKeyOptions) SetMasterKey(masterKey interface{}) *DataKeyOptions {
+	dk.MasterKey = masterKey
+	return dk
+}
+
+// SetKeyAltNames specifies an optional list of string alternate names used to reference a key. If a key is created'
+// with alternate names, encryption may refer to the key by a unique alternate name instead of by _id.
+func (dk *DataKeyOptions) SetKeyAltNames(keyAltNames []string) *DataKeyOptions {
+	dk.KeyAltNames = keyAltNames
+	return dk
+}
+
+// MergeDataKeyOptions combines the argued DataKeyOptions in a last-one wins fashion.
+func MergeDataKeyOptions(opts ...*DataKeyOptions) *DataKeyOptions {
+	dko := DataKey()
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+
+		if opt.MasterKey != nil {
+			dko.MasterKey = opt.MasterKey
+		}
+		if opt.KeyAltNames != nil {
+			dko.KeyAltNames = opt.KeyAltNames
+		}
+	}
+
+	return dko
+}

--- a/vendor/go.mongodb.org/mongo-driver/mongo/options/encryptoptions.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/options/encryptoptions.go
@@ -1,0 +1,64 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package options
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// EncryptOptions represents options to explicitly encrypt a value.
+type EncryptOptions struct {
+	KeyID      *primitive.Binary
+	KeyAltName *string
+	Algorithm  string
+}
+
+// Encrypt creates a new EncryptOptions instance.
+func Encrypt() *EncryptOptions {
+	return &EncryptOptions{}
+}
+
+// SetKeyID specifies an _id of a data key. This should be a UUID (a primitive.Binary with subtype 4).
+func (e *EncryptOptions) SetKeyID(keyID primitive.Binary) *EncryptOptions {
+	e.KeyID = &keyID
+	return e
+}
+
+// SetKeyAltName identifies a key vault document by 'keyAltName'.
+func (e *EncryptOptions) SetKeyAltName(keyAltName string) *EncryptOptions {
+	e.KeyAltName = &keyAltName
+	return e
+}
+
+// SetAlgorithm specifies an algorithm to use for encryption. This should be AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic
+// or AEAD_AES_256_CBC_HMAC_SHA_512-Random. This is required.
+func (e *EncryptOptions) SetAlgorithm(algorithm string) *EncryptOptions {
+	e.Algorithm = algorithm
+	return e
+}
+
+// MergeEncryptOptions combines the argued EncryptOptions in a last-one wins fashion.
+func MergeEncryptOptions(opts ...*EncryptOptions) *EncryptOptions {
+	eo := Encrypt()
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+
+		if opt.KeyID != nil {
+			eo.KeyID = opt.KeyID
+		}
+		if opt.KeyAltName != nil {
+			eo.KeyAltName = opt.KeyAltName
+		}
+		if opt.Algorithm != "" {
+			eo.Algorithm = opt.Algorithm
+		}
+	}
+
+	return eo
+}

--- a/vendor/go.mongodb.org/mongo-driver/mongo/options/indexoptions.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/options/indexoptions.go
@@ -105,6 +105,9 @@ func MergeListIndexesOptions(opts ...*ListIndexesOptions) *ListIndexesOptions {
 		if opt == nil {
 			continue
 		}
+		if opt.BatchSize != nil {
+			c.BatchSize = opt.BatchSize
+		}
 		if opt.MaxTime != nil {
 			c.MaxTime = opt.MaxTime
 		}

--- a/vendor/go.mongodb.org/mongo-driver/mongo/session.go
+++ b/vendor/go.mongodb.org/mongo-driver/mongo/session.go
@@ -14,12 +14,12 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/bsonx"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/operation"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 )
 
 // ErrWrongClient is returned when a user attempts to pass in a session created by a different client than
@@ -61,12 +61,32 @@ type Session interface {
 	session()
 }
 
+// XSession is an unstable interface for internal use only. This interface is deprecated and is not part of the
+// stability guarantee. It may be removed at any time.
+type XSession interface {
+	ClientSession() *session.Client
+	ID() bsonx.Doc
+}
+
 // sessionImpl represents a set of sequential operations executed by an application that are related in some way.
 type sessionImpl struct {
 	clientSession       *session.Client
 	client              *Client
-	topo                *topology.Topology
+	deployment          driver.Deployment
 	didCommitAfterStart bool // true if commit was called after start with no other operations
+}
+
+var _ Session = &sessionImpl{}
+var _ XSession = &sessionImpl{}
+
+// ClientSession implements the XSession interface.
+func (s *sessionImpl) ClientSession() *session.Client {
+	return s.clientSession
+}
+
+// ID implements the XSession interface.
+func (s *sessionImpl) ID() bsonx.Doc {
+	return s.clientSession.SessionID
 }
 
 // EndSession ends the session.
@@ -185,14 +205,14 @@ func (s *sessionImpl) AbortTransaction(ctx context.Context) error {
 	selector := makePinnedSelector(s.clientSession, description.WriteSelector())
 
 	s.clientSession.Aborting = true
-	err = operation.NewAbortTransaction().Session(s.clientSession).ClusterClock(s.client.clock).Database("admin").
-		Deployment(s.topo).WriteConcern(s.clientSession.CurrentWc).ServerSelector(selector).
+	_ = operation.NewAbortTransaction().Session(s.clientSession).ClusterClock(s.client.clock).Database("admin").
+		Deployment(s.deployment).WriteConcern(s.clientSession.CurrentWc).ServerSelector(selector).
 		Retry(driver.RetryOncePerCommand).CommandMonitor(s.client.monitor).RecoveryToken(bsoncore.Document(s.clientSession.RecoveryToken)).Execute(ctx)
 
 	s.clientSession.Aborting = false
 	_ = s.clientSession.AbortTransaction()
 
-	return replaceErrors(err)
+	return nil
 }
 
 // CommitTransaction commits the sesson's transaction.
@@ -216,7 +236,7 @@ func (s *sessionImpl) CommitTransaction(ctx context.Context) error {
 
 	s.clientSession.Committing = true
 	op := operation.NewCommitTransaction().
-		Session(s.clientSession).ClusterClock(s.client.clock).Database("admin").Deployment(s.topo).
+		Session(s.clientSession).ClusterClock(s.client.clock).Database("admin").Deployment(s.deployment).
 		WriteConcern(s.clientSession.CurrentWc).ServerSelector(selector).Retry(driver.RetryOncePerCommand).
 		CommandMonitor(s.client.monitor).RecoveryToken(bsoncore.Document(s.clientSession.RecoveryToken))
 	if s.clientSession.CurrentMct != nil {

--- a/vendor/go.mongodb.org/mongo-driver/version/version.go
+++ b/vendor/go.mongodb.org/mongo-driver/version/version.go
@@ -7,4 +7,4 @@
 package version // import "go.mongodb.org/mongo-driver/version"
 
 // Driver is the current version of the driver.
-var Driver = "v1.1.0"
+var Driver = "v1.1.1+prerelease"

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/batch_cursor.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/batch_cursor.go
@@ -29,6 +29,7 @@ type BatchCursor struct {
 	firstBatch           bool
 	cmdMonitor           *event.CommandMonitor
 	postBatchResumeToken bsoncore.Document
+	crypt                *Crypt
 
 	// legacy server (< 3.2) fields
 	legacy      bool // This field is provided for ListCollectionsBatchCursor.
@@ -101,6 +102,7 @@ type CursorOptions struct {
 	MaxTimeMS      int64
 	Limit          int32
 	CommandMonitor *event.CommandMonitor
+	Crypt          *Crypt
 }
 
 // NewBatchCursor creates a new BatchCursor from the provided parameters.
@@ -118,6 +120,7 @@ func NewBatchCursor(cr CursorResponse, clientSession *session.Client, clock *ses
 		cmdMonitor:           opts.CommandMonitor,
 		firstBatch:           true,
 		postBatchResumeToken: cr.postBatchResumeToken,
+		crypt:                opts.Crypt,
 	}
 
 	if ds != nil {
@@ -299,6 +302,7 @@ func (bc *BatchCursor) getMore(ctx context.Context) {
 		Clock:          bc.clock,
 		Legacy:         LegacyGetMore,
 		CommandMonitor: bc.cmdMonitor,
+		Crypt:          bc.crypt,
 	}.Execute(ctx, nil)
 
 	// Required for legacy operations which don't support limit.

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/batches.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/batches.go
@@ -39,16 +39,13 @@ func (b *Batches) AdvanceBatch(maxCount, targetBatchSize int) error {
 	if len(b.Current) > 0 {
 		return nil
 	}
-	if targetBatchSize > reservedCommandBufferBytes {
-		targetBatchSize -= reservedCommandBufferBytes
-	}
 
 	if maxCount <= 0 {
 		maxCount = 1
 	}
 
 	splitAfter := 0
-	size := 1
+	size := 0
 	for i, doc := range b.Documents {
 		if i == maxCount {
 			break

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/crypt.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/crypt.go
@@ -1,0 +1,327 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package driver
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"time"
+
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options"
+)
+
+const (
+	defaultKmsPort    = 443
+	defaultKmsTimeout = 10 * time.Second
+)
+
+// CollectionInfoFn is a callback used to retrieve collection information.
+type CollectionInfoFn func(ctx context.Context, db string, filter bsoncore.Document) (bsoncore.Document, error)
+
+// KeyRetrieverFn is a callback used to retrieve keys from the key vault.
+type KeyRetrieverFn func(ctx context.Context, filter bsoncore.Document) ([]bsoncore.Document, error)
+
+// MarkCommandFn is a callback used to add encryption markings to a command.
+type MarkCommandFn func(ctx context.Context, db string, cmd bsoncore.Document) (bsoncore.Document, error)
+
+// CryptOptions specifies options to configure a Crypt instance.
+type CryptOptions struct {
+	CollInfoFn           CollectionInfoFn
+	KeyFn                KeyRetrieverFn
+	MarkFn               MarkCommandFn
+	KmsProviders         map[string]map[string]interface{}
+	SchemaMap            map[string]bsoncore.Document
+	BypassAutoEncryption bool
+}
+
+// Crypt consumes the libmongocrypt.MongoCrypt type to iterate the mongocrypt state machine and perform encryption
+// and decryption.
+type Crypt struct {
+	mongoCrypt *mongocrypt.MongoCrypt
+	collInfoFn CollectionInfoFn
+	keyFn      KeyRetrieverFn
+	markFn     MarkCommandFn
+
+	BypassAutoEncryption bool
+}
+
+// NewCrypt creates a new Crypt instance configured with the given AutoEncryptionOptions.
+func NewCrypt(opts *CryptOptions) (*Crypt, error) {
+	c := &Crypt{
+		collInfoFn:           opts.CollInfoFn,
+		keyFn:                opts.KeyFn,
+		markFn:               opts.MarkFn,
+		BypassAutoEncryption: opts.BypassAutoEncryption,
+	}
+	mc, err := mongocrypt.NewMongoCrypt(createMongoCryptOptions(opts))
+	if err != nil {
+		return nil, err
+	}
+
+	c.mongoCrypt = mc
+	return c, nil
+}
+
+// Encrypt encrypts the given command.
+func (c *Crypt) Encrypt(ctx context.Context, db string, cmd bsoncore.Document) (bsoncore.Document, error) {
+	if c.BypassAutoEncryption {
+		return cmd, nil
+	}
+
+	cryptCtx, err := c.mongoCrypt.CreateEncryptionContext(db, cmd)
+	if err != nil {
+		return nil, err
+	}
+	defer cryptCtx.Close()
+
+	return c.executeStateMachine(ctx, cryptCtx, db)
+}
+
+// Decrypt decrypts the given command response.
+func (c *Crypt) Decrypt(ctx context.Context, cmdResponse bsoncore.Document) (bsoncore.Document, error) {
+	cryptCtx, err := c.mongoCrypt.CreateDecryptionContext(cmdResponse)
+	if err != nil {
+		return nil, err
+	}
+	defer cryptCtx.Close()
+
+	return c.executeStateMachine(ctx, cryptCtx, "")
+}
+
+// CreateDataKey creates a data key using the given KMS provider and options.
+func (c *Crypt) CreateDataKey(ctx context.Context, kmsProvider string, opts *options.DataKeyOptions) (bsoncore.Document, error) {
+	cryptCtx, err := c.mongoCrypt.CreateDataKeyContext(kmsProvider, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cryptCtx.Close()
+
+	return c.executeStateMachine(ctx, cryptCtx, "")
+}
+
+// EncryptExplicit encrypts the given value with the given options.
+func (c *Crypt) EncryptExplicit(ctx context.Context, val bsoncore.Value, opts *options.ExplicitEncryptionOptions) (byte, []byte, error) {
+	idx, doc := bsoncore.AppendDocumentStart(nil)
+	doc = bsoncore.AppendValueElement(doc, "v", val)
+	doc, _ = bsoncore.AppendDocumentEnd(doc, idx)
+
+	cryptCtx, err := c.mongoCrypt.CreateExplicitEncryptionContext(doc, opts)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer cryptCtx.Close()
+
+	res, err := c.executeStateMachine(ctx, cryptCtx, "")
+	if err != nil {
+		return 0, nil, err
+	}
+
+	sub, data := res.Lookup("v").Binary()
+	return sub, data, nil
+}
+
+// DecryptExplicit decrypts the given encrypted value.
+func (c *Crypt) DecryptExplicit(ctx context.Context, subtype byte, data []byte) (bsoncore.Value, error) {
+	idx, doc := bsoncore.AppendDocumentStart(nil)
+	doc = bsoncore.AppendBinaryElement(doc, "v", subtype, data)
+	doc, _ = bsoncore.AppendDocumentEnd(doc, idx)
+
+	cryptCtx, err := c.mongoCrypt.CreateExplicitDecryptionContext(doc)
+	if err != nil {
+		return bsoncore.Value{}, err
+	}
+	defer cryptCtx.Close()
+
+	res, err := c.executeStateMachine(ctx, cryptCtx, "")
+	if err != nil {
+		return bsoncore.Value{}, err
+	}
+
+	return res.Lookup("v"), nil
+}
+
+// Close cleans up any resources associated with the Crypt instance.
+func (c *Crypt) Close() {
+	c.mongoCrypt.Close()
+}
+
+func (c *Crypt) executeStateMachine(ctx context.Context, cryptCtx *mongocrypt.Context, db string) (bsoncore.Document, error) {
+	var err error
+	for {
+		state := cryptCtx.State()
+		switch state {
+		case mongocrypt.NeedMongoCollInfo:
+			err = c.collectionInfo(ctx, cryptCtx, db)
+		case mongocrypt.NeedMongoMarkings:
+			err = c.markCommand(ctx, cryptCtx, db)
+		case mongocrypt.NeedMongoKeys:
+			err = c.retrieveKeys(ctx, cryptCtx)
+		case mongocrypt.NeedKms:
+			err = c.decryptKeys(ctx, cryptCtx)
+		case mongocrypt.Ready:
+			return cryptCtx.Finish()
+		default:
+			return nil, fmt.Errorf("invalid Crypt state: %v", state)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (c *Crypt) collectionInfo(ctx context.Context, cryptCtx *mongocrypt.Context, db string) error {
+	op, err := cryptCtx.NextOperation()
+	if err != nil {
+		return err
+	}
+
+	collInfo, err := c.collInfoFn(ctx, db, op)
+	if err != nil {
+		return err
+	}
+	if collInfo != nil {
+		if err = cryptCtx.AddOperationResult(collInfo); err != nil {
+			return err
+		}
+	}
+
+	return cryptCtx.CompleteOperation()
+}
+
+func (c *Crypt) markCommand(ctx context.Context, cryptCtx *mongocrypt.Context, db string) error {
+	op, err := cryptCtx.NextOperation()
+	if err != nil {
+		return err
+	}
+
+	markedCmd, err := c.markFn(ctx, db, op)
+	if err != nil {
+		return err
+	}
+	if err = cryptCtx.AddOperationResult(markedCmd); err != nil {
+		return err
+	}
+
+	return cryptCtx.CompleteOperation()
+}
+
+func (c *Crypt) retrieveKeys(ctx context.Context, cryptCtx *mongocrypt.Context) error {
+	op, err := cryptCtx.NextOperation()
+	if err != nil {
+		return err
+	}
+
+	keys, err := c.keyFn(ctx, op)
+	if err != nil {
+		return err
+	}
+
+	for _, key := range keys {
+		if err = cryptCtx.AddOperationResult(key); err != nil {
+			return err
+		}
+	}
+
+	return cryptCtx.CompleteOperation()
+}
+
+func (c *Crypt) decryptKeys(ctx context.Context, cryptCtx *mongocrypt.Context) error {
+	for {
+		kmsCtx := cryptCtx.NextKmsContext()
+		if kmsCtx == nil {
+			break
+		}
+
+		if err := c.decryptKey(ctx, kmsCtx); err != nil {
+			return err
+		}
+	}
+
+	return cryptCtx.FinishKmsContexts()
+}
+
+func (c *Crypt) decryptKey(ctx context.Context, kmsCtx *mongocrypt.KmsContext) error {
+	host, err := kmsCtx.HostName()
+	if err != nil {
+		return err
+	}
+	msg, err := kmsCtx.Message()
+	if err != nil {
+		return err
+	}
+
+	addr := fmt.Sprintf("%s:%d", host, defaultKmsPort)
+	conn, err := tls.Dial("tcp", addr, &tls.Config{})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	if err = conn.SetWriteDeadline(time.Now().Add(defaultKmsTimeout)); err != nil {
+		return err
+	}
+	if _, err = conn.Write(msg); err != nil {
+		return err
+	}
+
+	for {
+		bytesNeeded := kmsCtx.BytesNeeded()
+		if bytesNeeded == 0 {
+			return nil
+		}
+
+		res := make([]byte, bytesNeeded)
+		bytesRead, err := conn.Read(res)
+		if err != nil && err != io.EOF {
+			return err
+		}
+
+		if err = kmsCtx.FeedResponse(res[:bytesRead]); err != nil {
+			return err
+		}
+	}
+}
+
+func createMongoCryptOptions(opts *CryptOptions) *options.MongoCryptOptions {
+	mcOpts := options.MongoCrypt().SetLocalSchemaMap(opts.SchemaMap)
+	// KMS providers options
+	for provider, providerOpts := range opts.KmsProviders {
+		switch provider {
+		case "aws":
+			awsOpts := options.AwsKmsProvider()
+
+			if accessKey, ok := providerOpts["accessKeyId"]; ok {
+				if keyStr, ok := accessKey.(string); ok {
+					awsOpts.SetAccessKeyID(keyStr)
+				}
+			}
+			if secretAccessKey, ok := providerOpts["secretAccessKey"]; ok {
+				if keyStr, ok := secretAccessKey.(string); ok {
+					awsOpts.SetSecretAccessKey(keyStr)
+				}
+			}
+			mcOpts.SetAwsProviderOptions(awsOpts)
+		case "local":
+			localOpts := options.LocalKmsProvider()
+
+			if key, ok := providerOpts["key"]; ok {
+				if keyBytes, ok := key.([]byte); ok {
+					localOpts.SetMasterKey(keyBytes)
+				}
+			}
+			mcOpts.SetLocalProviderOptions(localOpts)
+		}
+	}
+
+	return mcOpts
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/driver.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/driver.go
@@ -14,6 +14,30 @@ type Deployment interface {
 	Kind() description.TopologyKind
 }
 
+// Connector represents a type that can connect to a server.
+type Connector interface {
+	Connect() error
+}
+
+// Disconnector represents a type that can disconnect from a server.
+type Disconnector interface {
+	Disconnect(context.Context) error
+}
+
+// Subscription represents a subscription to topology updates. A subscriber can receive updates through the
+// Updates field.
+type Subscription struct {
+	Updates <-chan description.Topology
+	ID      uint64
+}
+
+// Subscriber represents a type to which another type can subscribe. A subscription contains a channel that
+// is updated with topology descriptions.
+type Subscriber interface {
+	Subscribe() (*Subscription, error)
+	Unsubscribe(*Subscription) error
+}
+
 // Server represents a MongoDB server. Implementations should pool connections and handle the
 // retrieving and returning of connections.
 type Server interface {

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/binary.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/binary.go
@@ -1,0 +1,55 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// +build cse
+
+package mongocrypt
+
+// #include <mongocrypt.h>
+import "C"
+import (
+	"unsafe"
+)
+
+// binary is a wrapper type around a mongocrypt_binary_t*
+type binary struct {
+	wrapped *C.mongocrypt_binary_t
+}
+
+// newBinary creates an empty binary instance.
+func newBinary() *binary {
+	return &binary{
+		wrapped: C.mongocrypt_binary_new(),
+	}
+}
+
+// newBinaryFromBytes creates a binary instance from a byte buffer.
+func newBinaryFromBytes(data []byte) *binary {
+	if len(data) == 0 {
+		return newBinary()
+	}
+
+	// We don't need C.CBytes here because data cannot go out of scope. Any mongocrypt function that takes a
+	// mongocrypt_binary_t will make a copy of the data so the data can be garbage collected after calling.
+	addr := (*C.uint8_t)(unsafe.Pointer(&data[0])) // uint8_t*
+	dataLen := C.uint32_t(len(data))               // uint32_t
+	return &binary{
+		wrapped: C.mongocrypt_binary_new_from_data(addr, dataLen),
+	}
+}
+
+// toBytes converts the given binary instance to []byte.
+func (b *binary) toBytes() []byte {
+	dataPtr := C.mongocrypt_binary_data(b.wrapped) // C.uint8_t*
+	dataLen := C.mongocrypt_binary_len(b.wrapped)  // C.uint32_t
+
+	return C.GoBytes(unsafe.Pointer(dataPtr), C.int(dataLen))
+}
+
+// close cleans up any resources associated with the given binary instance.
+func (b *binary) close() {
+	C.mongocrypt_binary_destroy(b.wrapped)
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/errors.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/errors.go
@@ -1,0 +1,43 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// +build cse
+
+package mongocrypt
+
+// #include <mongocrypt.h>
+import "C"
+import (
+	"fmt"
+)
+
+// Error represents an error from an operation on a MongoCrypt instance.
+type Error struct {
+	Code    int32
+	Message string
+}
+
+// Error implements the error interface.
+func (e Error) Error() string {
+	return fmt.Sprintf("mongocrypt error %d: %v", e.Code, e.Message)
+}
+
+// errorFromStatus builds a Error from a mongocrypt_status_t object.
+func errorFromStatus(status *C.mongocrypt_status_t) error {
+	cCode := C.mongocrypt_status_code(status) // uint32_t
+	// mongocrypt_status_message takes uint32_t* as its second param to store the length of the returned string.
+	// pass nil because the length is handled by C.GoString
+	cMsg := C.mongocrypt_status_message(status, nil) // const char*
+	var msg string
+	if cMsg != nil {
+		msg = C.GoString(cMsg)
+	}
+
+	return Error{
+		Code:    int32(cCode),
+		Message: msg,
+	}
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/errors_not_enabled.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/errors_not_enabled.go
@@ -1,0 +1,20 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// +build !cse
+
+package mongocrypt
+
+// Error represents an error from an operation on a MongoCrypt instance.
+type Error struct {
+	Code    int32
+	Message string
+}
+
+// Error implements the error interface
+func (Error) Error() string {
+	panic(cseNotSupportedMsg)
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -1,0 +1,280 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// +build cse
+
+package mongocrypt
+
+// #cgo linux solaris darwin pkg-config: libmongocrypt
+// #cgo windows CFLAGS: -I"c:/libmongocrypt/include"
+// #cgo windows LDFLAGS: -lmongocrypt -Lc:/libmongocrypt/bin
+// #include <mongocrypt.h>
+// #include <stdlib.h>
+import "C"
+import (
+	"unsafe"
+
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options"
+)
+
+// These constants reprsent valid values for KmsProvider.
+const (
+	AwsProvider   = "aws"
+	LocalProvider = "local"
+)
+
+// ErrInvalidProvider is returned when an invalid KMS provider is given.
+var ErrInvalidProvider = errors.New("invalid KMS provider")
+
+// MongoCrypt represents a mongocrypt_t handle.
+type MongoCrypt struct {
+	wrapped *C.mongocrypt_t
+}
+
+// NewMongoCrypt constructs a new MongoCrypt instance configured using the provided MongoCryptOptions.
+func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
+	// create mongocrypt_t handle
+	wrapped := C.mongocrypt_new()
+	if wrapped == nil {
+		return nil, errors.New("could not create new mongocrypt object")
+	}
+	crypt := &MongoCrypt{
+		wrapped: wrapped,
+	}
+
+	// set options in mongocrypt
+	if err := crypt.setLocalProviderOpts(opts.LocalProviderOpts); err != nil {
+		return nil, err
+	}
+	if err := crypt.setAwsProviderOpts(opts.AwsProviderOpts); err != nil {
+		return nil, err
+	}
+	if err := crypt.setLocalSchemaMap(opts.LocalSchemaMap); err != nil {
+		return nil, err
+	}
+
+	// initialize handle
+	if !C.mongocrypt_init(crypt.wrapped) {
+		return nil, crypt.createErrorFromStatus()
+	}
+	return crypt, nil
+}
+
+// CreateEncryptionContext creates a Context to use for encryption.
+func (m *MongoCrypt) CreateEncryptionContext(db string, cmd bsoncore.Document) (*Context, error) {
+	ctx := newContext(C.mongocrypt_ctx_new(m.wrapped))
+	if ctx.wrapped == nil {
+		return nil, m.createErrorFromStatus()
+	}
+
+	cmdBinary := newBinaryFromBytes(cmd)
+	defer cmdBinary.close()
+	dbStr := C.CString(db)
+	defer C.free(unsafe.Pointer(dbStr))
+
+	if ok := C.mongocrypt_ctx_encrypt_init(ctx.wrapped, dbStr, C.int32_t(-1), cmdBinary.wrapped); !ok {
+		return nil, ctx.createErrorFromStatus()
+	}
+	return ctx, nil
+}
+
+// CreateDecryptionContext creates a Context to use for decryption.
+func (m *MongoCrypt) CreateDecryptionContext(cmd bsoncore.Document) (*Context, error) {
+	ctx := newContext(C.mongocrypt_ctx_new(m.wrapped))
+	if ctx.wrapped == nil {
+		return nil, m.createErrorFromStatus()
+	}
+
+	cmdBinary := newBinaryFromBytes(cmd)
+	defer cmdBinary.close()
+
+	if ok := C.mongocrypt_ctx_decrypt_init(ctx.wrapped, cmdBinary.wrapped); !ok {
+		return nil, ctx.createErrorFromStatus()
+	}
+	return ctx, nil
+}
+
+// lookupString returns a string for the value corresponding to the given key in the document.
+// if the key does not exist or the value is not a string, the empty string is returned.
+func lookupString(doc bsoncore.Document, key string) string {
+	strVal, _ := doc.Lookup(key).StringValueOK()
+	return strVal
+}
+
+func setAltName(ctx *Context, altName string) error {
+	// create document {"keyAltName": keyAltName}
+	idx, doc := bsoncore.AppendDocumentStart(nil)
+	doc = bsoncore.AppendStringElement(doc, "keyAltName", altName)
+	doc, _ = bsoncore.AppendDocumentEnd(doc, idx)
+
+	keyAltBinary := newBinaryFromBytes(doc)
+	defer keyAltBinary.close()
+
+	if ok := C.mongocrypt_ctx_setopt_key_alt_name(ctx.wrapped, keyAltBinary.wrapped); !ok {
+		return ctx.createErrorFromStatus()
+	}
+	return nil
+}
+
+// CreateDataKeyContext creates a Context to use for creating a data key.
+func (m *MongoCrypt) CreateDataKeyContext(kmsProvider string, opts *options.DataKeyOptions) (*Context, error) {
+	ctx := newContext(C.mongocrypt_ctx_new(m.wrapped))
+	if ctx.wrapped == nil {
+		return nil, m.createErrorFromStatus()
+	}
+
+	var ok bool
+	switch kmsProvider {
+	case AwsProvider:
+		region := C.CString(lookupString(opts.MasterKey, "region"))
+		key := C.CString(lookupString(opts.MasterKey, "key"))
+		defer C.free(unsafe.Pointer(region))
+		defer C.free(unsafe.Pointer(key))
+
+		ok = bool(C.mongocrypt_ctx_setopt_masterkey_aws(ctx.wrapped, region, -1, key, -1))
+	case LocalProvider:
+		ok = bool(C.mongocrypt_ctx_setopt_masterkey_local(ctx.wrapped))
+	default:
+		return nil, ErrInvalidProvider
+	}
+	if !ok {
+		return nil, ctx.createErrorFromStatus()
+	}
+
+	for _, altName := range opts.KeyAltNames {
+		if err := setAltName(ctx, altName); err != nil {
+			return nil, err
+		}
+	}
+
+	if ok := C.mongocrypt_ctx_datakey_init(ctx.wrapped); !ok {
+		return nil, ctx.createErrorFromStatus()
+	}
+	return ctx, nil
+}
+
+// CreateExplicitEncryptionContext creates a Context to use for explicit encryption.
+func (m *MongoCrypt) CreateExplicitEncryptionContext(doc bsoncore.Document, opts *options.ExplicitEncryptionOptions) (*Context, error) {
+
+	ctx := newContext(C.mongocrypt_ctx_new(m.wrapped))
+	if ctx.wrapped == nil {
+		return nil, m.createErrorFromStatus()
+	}
+
+	if opts.KeyID != nil {
+		keyIDBinary := newBinaryFromBytes(opts.KeyID.Data)
+		defer keyIDBinary.close()
+
+		if ok := C.mongocrypt_ctx_setopt_key_id(ctx.wrapped, keyIDBinary.wrapped); !ok {
+			return nil, ctx.createErrorFromStatus()
+		}
+	}
+	if opts.KeyAltName != nil {
+		if err := setAltName(ctx, *opts.KeyAltName); err != nil {
+			return nil, err
+		}
+	}
+
+	algoStr := C.CString(opts.Algorithm)
+	defer C.free(unsafe.Pointer(algoStr))
+	if ok := C.mongocrypt_ctx_setopt_algorithm(ctx.wrapped, algoStr, -1); !ok {
+		return nil, ctx.createErrorFromStatus()
+	}
+
+	docBinary := newBinaryFromBytes(doc)
+	defer docBinary.close()
+	if ok := C.mongocrypt_ctx_explicit_encrypt_init(ctx.wrapped, docBinary.wrapped); !ok {
+		return nil, ctx.createErrorFromStatus()
+	}
+
+	return ctx, nil
+}
+
+// CreateExplicitDecryptionContext creates a Context to use for explicit decryption.
+func (m *MongoCrypt) CreateExplicitDecryptionContext(doc bsoncore.Document) (*Context, error) {
+	ctx := newContext(C.mongocrypt_ctx_new(m.wrapped))
+	if ctx.wrapped == nil {
+		return nil, m.createErrorFromStatus()
+	}
+
+	docBinary := newBinaryFromBytes(doc)
+	defer docBinary.close()
+
+	if ok := C.mongocrypt_ctx_explicit_decrypt_init(ctx.wrapped, docBinary.wrapped); !ok {
+		return nil, ctx.createErrorFromStatus()
+	}
+	return ctx, nil
+}
+
+// Close cleans up any resources associated with the given MongoCrypt instance.
+func (m *MongoCrypt) Close() {
+	C.mongocrypt_destroy(m.wrapped)
+}
+
+// setLocalProviderOpts sets options for the local KMS provider in mongocrypt.
+func (m *MongoCrypt) setLocalProviderOpts(opts *options.LocalKmsProviderOptions) error {
+	if opts == nil {
+		return nil
+	}
+
+	keyBinary := newBinaryFromBytes(opts.MasterKey)
+	defer keyBinary.close()
+
+	if ok := C.mongocrypt_setopt_kms_provider_local(m.wrapped, keyBinary.wrapped); !ok {
+		return m.createErrorFromStatus()
+	}
+	return nil
+}
+
+// setAwsProviderOpts sets options for the AWS KMS provider in mongocrypt.
+func (m *MongoCrypt) setAwsProviderOpts(opts *options.AwsKmsProviderOptions) error {
+	if opts == nil {
+		return nil
+	}
+
+	// create C strings for function params
+	accessKeyID := C.CString(opts.AccessKeyID)
+	secretAccessKey := C.CString(opts.SecretAccessKey)
+	defer C.free(unsafe.Pointer(accessKeyID))
+	defer C.free(unsafe.Pointer(secretAccessKey))
+
+	if ok := C.mongocrypt_setopt_kms_provider_aws(m.wrapped, accessKeyID, C.int32_t(-1), secretAccessKey, C.int32_t(-1)); !ok {
+		return m.createErrorFromStatus()
+	}
+	return nil
+}
+
+// setLocalSchemaMap sets the local schema map in mongocrypt.
+func (m *MongoCrypt) setLocalSchemaMap(schemaMap map[string]bsoncore.Document) error {
+	if len(schemaMap) == 0 {
+		return nil
+	}
+
+	// convert schema map to BSON document
+	midx, mdoc := bsoncore.AppendDocumentStart(nil)
+	for key, doc := range schemaMap {
+		mdoc = bsoncore.AppendDocumentElement(mdoc, key, doc)
+	}
+	mdoc, _ = bsoncore.AppendDocumentEnd(mdoc, midx)
+
+	schemaMapBinary := newBinaryFromBytes(mdoc)
+	defer schemaMapBinary.close()
+
+	if ok := C.mongocrypt_setopt_schema_map(m.wrapped, schemaMapBinary.wrapped); !ok {
+		return m.createErrorFromStatus()
+	}
+	return nil
+}
+
+// createErrorFromStatus creates a new Error based on the status of the MongoCrypt instance.
+func (m *MongoCrypt) createErrorFromStatus() error {
+	status := C.mongocrypt_status_new()
+	defer C.mongocrypt_status_destroy(status)
+	C.mongocrypt_status(m.wrapped, status)
+	return errorFromStatus(status)
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt_context.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt_context.go
@@ -1,0 +1,103 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// +build cse
+
+package mongocrypt
+
+// #include <mongocrypt.h>
+import "C"
+import (
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+// Context represents a mongocrypt_ctx_t handle
+type Context struct {
+	wrapped *C.mongocrypt_ctx_t
+}
+
+// newContext creates a Context wrapper around the given C type.
+func newContext(wrapped *C.mongocrypt_ctx_t) *Context {
+	return &Context{
+		wrapped: wrapped,
+	}
+}
+
+// State returns the current State of the Context.
+func (c *Context) State() State {
+	return State(int(C.mongocrypt_ctx_state(c.wrapped)))
+}
+
+// NextOperation gets the document for the next database operation to run.
+func (c *Context) NextOperation() (bsoncore.Document, error) {
+	opDocBinary := newBinary() // out param for mongocrypt_ctx_mongo_op to fill in operation
+	defer opDocBinary.close()
+
+	if ok := C.mongocrypt_ctx_mongo_op(c.wrapped, opDocBinary.wrapped); !ok {
+		return nil, c.createErrorFromStatus()
+	}
+	return opDocBinary.toBytes(), nil
+}
+
+// AddOperationResult feeds the result of a database operation to mongocrypt.
+func (c *Context) AddOperationResult(result bsoncore.Document) error {
+	resultBinary := newBinaryFromBytes(result)
+	defer resultBinary.close()
+
+	if ok := C.mongocrypt_ctx_mongo_feed(c.wrapped, resultBinary.wrapped); !ok {
+		return c.createErrorFromStatus()
+	}
+	return nil
+}
+
+// CompleteOperation signals a database operation has been completed.
+func (c *Context) CompleteOperation() error {
+	if ok := C.mongocrypt_ctx_mongo_done(c.wrapped); !ok {
+		return c.createErrorFromStatus()
+	}
+	return nil
+}
+
+// NextKmsContext returns the next KmsContext, or nil if there are no more.
+func (c *Context) NextKmsContext() *KmsContext {
+	ctx := C.mongocrypt_ctx_next_kms_ctx(c.wrapped)
+	if ctx == nil {
+		return nil
+	}
+	return newKmsContext(ctx)
+}
+
+// FinishKmsContexts signals that all KMS contexts have been completed.
+func (c *Context) FinishKmsContexts() error {
+	if ok := C.mongocrypt_ctx_kms_done(c.wrapped); !ok {
+		return c.createErrorFromStatus()
+	}
+	return nil
+}
+
+// Finish performs the final operations for the context and returns the resulting document.
+func (c *Context) Finish() (bsoncore.Document, error) {
+	docBinary := newBinary() // out param for mongocrypt_ctx_finalize to fill in resulting document
+	defer docBinary.close()
+
+	if ok := C.mongocrypt_ctx_finalize(c.wrapped, docBinary.wrapped); !ok {
+		return nil, c.createErrorFromStatus()
+	}
+	return docBinary.toBytes(), nil
+}
+
+// Close cleans up any resources associated with the given Context instance.
+func (c *Context) Close() {
+	C.mongocrypt_ctx_destroy(c.wrapped)
+}
+
+// createErrorFromStatus creates a new Error based on the status of the MongoCrypt instance.
+func (c *Context) createErrorFromStatus() error {
+	status := C.mongocrypt_status_new()
+	defer C.mongocrypt_status_destroy(status)
+	C.mongocrypt_ctx_status(c.wrapped, status)
+	return errorFromStatus(status)
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt_context_not_enabled.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt_context_not_enabled.go
@@ -1,0 +1,56 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// +build !cse
+
+package mongocrypt
+
+import (
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+// Context represents a mongocrypt_ctx_t handle
+type Context struct{}
+
+// State returns the current State of the Context.
+func (c *Context) State() State {
+	panic(cseNotSupportedMsg)
+}
+
+// NextOperation gets the document for the next database operation to run.
+func (c *Context) NextOperation() (bsoncore.Document, error) {
+	panic(cseNotSupportedMsg)
+}
+
+// AddOperationResult feeds the result of a database operation to mongocrypt.
+func (c *Context) AddOperationResult(result bsoncore.Document) error {
+	panic(cseNotSupportedMsg)
+}
+
+// CompleteOperation signals a database operation has been completed.
+func (c *Context) CompleteOperation() error {
+	panic(cseNotSupportedMsg)
+}
+
+// NextKmsContext returns the next KmsContext, or nil if there are no more.
+func (c *Context) NextKmsContext() *KmsContext {
+	panic(cseNotSupportedMsg)
+}
+
+// FinishKmsContexts signals that all KMS contexts have been completed.
+func (c *Context) FinishKmsContexts() error {
+	panic(cseNotSupportedMsg)
+}
+
+// Finish performs the final operations for the context and returns the resulting document.
+func (c *Context) Finish() (bsoncore.Document, error) {
+	panic(cseNotSupportedMsg)
+}
+
+// Close cleans up any resources associated with the given Context instance.
+func (c *Context) Close() {
+	panic(cseNotSupportedMsg)
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt_kms_context.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt_kms_context.go
@@ -1,0 +1,69 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// +build cse
+
+package mongocrypt
+
+// #include <mongocrypt.h>
+import "C"
+
+// KmsContext represents a mongocrypt_kms_ctx_t handle.
+type KmsContext struct {
+	wrapped *C.mongocrypt_kms_ctx_t
+}
+
+// newKmsContext creates a KmsContext wrapper around the given C type.
+func newKmsContext(wrapped *C.mongocrypt_kms_ctx_t) *KmsContext {
+	return &KmsContext{
+		wrapped: wrapped,
+	}
+}
+
+// HostName gets the host name of the KMS.
+func (kc *KmsContext) HostName() (string, error) {
+	var hostname *C.char // out param for mongocrypt function to fill in hostname
+	if ok := C.mongocrypt_kms_ctx_endpoint(kc.wrapped, &hostname); !ok {
+		return "", kc.createErrorFromStatus()
+	}
+	return C.GoString(hostname), nil
+}
+
+// Message returns the message to send to the KMS.
+func (kc *KmsContext) Message() ([]byte, error) {
+	msgBinary := newBinary()
+	defer msgBinary.close()
+
+	if ok := C.mongocrypt_kms_ctx_message(kc.wrapped, msgBinary.wrapped); !ok {
+		return nil, kc.createErrorFromStatus()
+	}
+	return msgBinary.toBytes(), nil
+}
+
+// BytesNeeded returns the number of bytes that should be received from the KMS.
+// After sending the message to the KMS, this message should be called in a loop until the number returned is 0.
+func (kc *KmsContext) BytesNeeded() int32 {
+	return int32(C.mongocrypt_kms_ctx_bytes_needed(kc.wrapped))
+}
+
+// FeedResponse feeds the bytes received from the KMS to mongocrypt.
+func (kc *KmsContext) FeedResponse(response []byte) error {
+	responseBinary := newBinaryFromBytes(response)
+	defer responseBinary.close()
+
+	if ok := C.mongocrypt_kms_ctx_feed(kc.wrapped, responseBinary.wrapped); !ok {
+		return kc.createErrorFromStatus()
+	}
+	return nil
+}
+
+// createErrorFromStatus creates a new Error from the status of the KmsContext instance.
+func (kc *KmsContext) createErrorFromStatus() error {
+	status := C.mongocrypt_status_new()
+	defer C.mongocrypt_status_destroy(status)
+	C.mongocrypt_kms_ctx_status(kc.wrapped, status)
+	return errorFromStatus(status)
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt_kms_context_not_enabled.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt_kms_context_not_enabled.go
@@ -1,0 +1,38 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// +build !cse
+
+package mongocrypt
+
+// KmsContext represents a mongocrypt_kms_ctx_t handle.
+type KmsContext struct{}
+
+// HostName gets the host name of the KMS.
+func (kc *KmsContext) HostName() (string, error) {
+	panic(cseNotSupportedMsg)
+}
+
+// Message returns the message to send to the KMS.
+func (kc *KmsContext) Message() ([]byte, error) {
+	panic(cseNotSupportedMsg)
+}
+
+// BytesNeeded returns the number of bytes that should be received from the KMS.
+// After sending the message to the KMS, this message should be called in a loop until the number returned is 0.
+func (kc *KmsContext) BytesNeeded() int32 {
+	panic(cseNotSupportedMsg)
+}
+
+// FeedResponse feeds the bytes received from the KMS to mongocrypt.
+func (kc *KmsContext) FeedResponse(response []byte) error {
+	panic(cseNotSupportedMsg)
+}
+
+// createErrorFromStatus creates a new Error from the status of the KmsContext instance.
+func (kc *KmsContext) createErrorFromStatus() error {
+	panic(cseNotSupportedMsg)
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
@@ -1,0 +1,54 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+// +build !cse
+
+package mongocrypt
+
+import (
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options"
+)
+
+const cseNotSupportedMsg = "client-side encryption not enabled. add the cse build tag to support"
+
+// MongoCrypt represents a mongocrypt_t handle.
+type MongoCrypt struct{}
+
+// NewMongoCrypt constructs a new MongoCrypt instance configured using the provided MongoCryptOptions.
+func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
+	panic(cseNotSupportedMsg)
+}
+
+// CreateEncryptionContext creates a Context to use for encryption.
+func (m *MongoCrypt) CreateEncryptionContext(db string, cmd bsoncore.Document) (*Context, error) {
+	panic(cseNotSupportedMsg)
+}
+
+// CreateDecryptionContext creates a Context to use for decryption.
+func (m *MongoCrypt) CreateDecryptionContext(cmd bsoncore.Document) (*Context, error) {
+	panic(cseNotSupportedMsg)
+}
+
+// CreateDataKeyContext creates a Context to use for creating a data key.
+func (m *MongoCrypt) CreateDataKeyContext(kmsProvider string, opts *options.DataKeyOptions) (*Context, error) {
+	panic(cseNotSupportedMsg)
+}
+
+// CreateExplicitEncryptionContext creates a Context to use for explicit encryption.
+func (m *MongoCrypt) CreateExplicitEncryptionContext(doc bsoncore.Document, opts *options.ExplicitEncryptionOptions) (*Context, error) {
+	panic(cseNotSupportedMsg)
+}
+
+// CreateExplicitDecryptionContext creates a Context to use for explicit decryption.
+func (m *MongoCrypt) CreateExplicitDecryptionContext(doc bsoncore.Document) (*Context, error) {
+	panic(cseNotSupportedMsg)
+}
+
+// Close cleans up any resources associated with the given MongoCrypt instance.
+func (m *MongoCrypt) Close() {
+	panic(cseNotSupportedMsg)
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options/mongocrypt_context_options.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options/mongocrypt_context_options.go
@@ -1,0 +1,65 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package options
+
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+// DataKeyOptions specifies options for creating a new data key.
+type DataKeyOptions struct {
+	KeyAltNames []string
+	MasterKey   bsoncore.Document
+}
+
+// DataKey creates a new DataKeyOptions instance.
+func DataKey() *DataKeyOptions {
+	return &DataKeyOptions{}
+}
+
+// SetKeyAltNames specifies alternate key names.
+func (dko *DataKeyOptions) SetKeyAltNames(names []string) *DataKeyOptions {
+	dko.KeyAltNames = names
+	return dko
+}
+
+// SetMasterKey specifies the master key.
+func (dko *DataKeyOptions) SetMasterKey(key bsoncore.Document) *DataKeyOptions {
+	dko.MasterKey = key
+	return dko
+}
+
+// ExplicitEncryptionOptions specifies options for configuring an explicit encryption context.
+type ExplicitEncryptionOptions struct {
+	KeyID      *primitive.Binary
+	KeyAltName *string
+	Algorithm  string
+}
+
+// ExplicitEncryption creates a new ExplicitEncryptionOptions instance.
+func ExplicitEncryption() *ExplicitEncryptionOptions {
+	return &ExplicitEncryptionOptions{}
+}
+
+// SetKeyID sets the key identifier.
+func (eeo *ExplicitEncryptionOptions) SetKeyID(keyID primitive.Binary) *ExplicitEncryptionOptions {
+	eeo.KeyID = &keyID
+	return eeo
+}
+
+// SetKeyAltName sets the key alternative name.
+func (eeo *ExplicitEncryptionOptions) SetKeyAltName(keyAltName string) *ExplicitEncryptionOptions {
+	eeo.KeyAltName = &keyAltName
+	return eeo
+}
+
+// SetAlgorithm specifies an encryption algorithm.
+func (eeo *ExplicitEncryptionOptions) SetAlgorithm(algorithm string) *ExplicitEncryptionOptions {
+	eeo.Algorithm = algorithm
+	return eeo
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options/mongocrypt_options.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options/mongocrypt_options.go
@@ -1,0 +1,41 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package options
+
+import (
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+// MongoCryptOptions specifies options to configure a MongoCrypt instance.
+type MongoCryptOptions struct {
+	AwsProviderOpts   *AwsKmsProviderOptions
+	LocalProviderOpts *LocalKmsProviderOptions
+	LocalSchemaMap    map[string]bsoncore.Document
+}
+
+// MongoCrypt creates a new MongoCryptOptions instance.
+func MongoCrypt() *MongoCryptOptions {
+	return &MongoCryptOptions{}
+}
+
+// SetAwsProviderOptions specifies AWS KMS provider options.
+func (mo *MongoCryptOptions) SetAwsProviderOptions(awsOpts *AwsKmsProviderOptions) *MongoCryptOptions {
+	mo.AwsProviderOpts = awsOpts
+	return mo
+}
+
+// SetLocalProviderOptions specifies local KMS provider options.
+func (mo *MongoCryptOptions) SetLocalProviderOptions(localOpts *LocalKmsProviderOptions) *MongoCryptOptions {
+	mo.LocalProviderOpts = localOpts
+	return mo
+}
+
+// SetLocalSchemaMap specifies the local schema map.
+func (mo *MongoCryptOptions) SetLocalSchemaMap(localSchemaMap map[string]bsoncore.Document) *MongoCryptOptions {
+	mo.LocalSchemaMap = localSchemaMap
+	return mo
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options/provider_options.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/options/provider_options.go
@@ -1,0 +1,46 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package options
+
+// AwsKmsProviderOptions specifies options for configuring the AWS KMS provider.
+type AwsKmsProviderOptions struct {
+	AccessKeyID     string
+	SecretAccessKey string
+}
+
+// AwsKmsProvider creates a new AwsKmsProviderOptions instance.
+func AwsKmsProvider() *AwsKmsProviderOptions {
+	return &AwsKmsProviderOptions{}
+}
+
+// SetAccessKeyID specifies the AWS access key ID.
+func (akpo *AwsKmsProviderOptions) SetAccessKeyID(accessKeyID string) *AwsKmsProviderOptions {
+	akpo.AccessKeyID = accessKeyID
+	return akpo
+}
+
+// SetSecretAccessKey specifies the AWS secret access key.
+func (akpo *AwsKmsProviderOptions) SetSecretAccessKey(secretAccessKey string) *AwsKmsProviderOptions {
+	akpo.SecretAccessKey = secretAccessKey
+	return akpo
+}
+
+// LocalKmsProviderOptions specifies options for configuring a local KMS provider.
+type LocalKmsProviderOptions struct {
+	MasterKey []byte
+}
+
+// LocalKmsProvider creates a new LocalKmsProviderOptions instance.
+func LocalKmsProvider() *LocalKmsProviderOptions {
+	return &LocalKmsProviderOptions{}
+}
+
+// SetMasterKey specifies the local master key.
+func (lkpo *LocalKmsProviderOptions) SetMasterKey(key []byte) *LocalKmsProviderOptions {
+	lkpo.MasterKey = key
+	return lkpo
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/state.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/mongocrypt/state.go
@@ -1,0 +1,43 @@
+// Copyright (C) MongoDB, Inc. 2017-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package mongocrypt
+
+// State represents a state that a MongocryptContext can be in.
+type State int
+
+// These constants are valid values for the State type.
+const (
+	StateError State = iota
+	NeedMongoCollInfo
+	NeedMongoMarkings
+	NeedMongoKeys
+	NeedKms
+	Ready
+	Done
+)
+
+// String implements the Stringer interface.
+func (s State) String() string {
+	switch s {
+	case StateError:
+		return "Error"
+	case NeedMongoCollInfo:
+		return "NeedMongoCollInfo"
+	case NeedMongoMarkings:
+		return "NeedMongoMarkings"
+	case NeedMongoKeys:
+		return "NeedMongoKeys"
+	case NeedKms:
+		return "NeedKms"
+	case Ready:
+		return "Ready"
+	case Done:
+		return "Done"
+	default:
+		return "Unknown State"
+	}
+}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/abort_transaction.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/abort_transaction.go
@@ -27,6 +27,7 @@ type AbortTransaction struct {
 	clock         *session.ClusterClock
 	collection    string
 	monitor       *event.CommandMonitor
+	crypt         *driver.Crypt
 	database      string
 	deployment    driver.Deployment
 	selector      description.ServerSelector
@@ -58,6 +59,7 @@ func (at *AbortTransaction) Execute(ctx context.Context) error {
 		Client:            at.session,
 		Clock:             at.clock,
 		CommandMonitor:    at.monitor,
+		Crypt:             at.crypt,
 		Database:          at.database,
 		Deployment:        at.deployment,
 		Selector:          at.selector,
@@ -122,6 +124,16 @@ func (at *AbortTransaction) CommandMonitor(monitor *event.CommandMonitor) *Abort
 	}
 
 	at.monitor = monitor
+	return at
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (at *AbortTransaction) Crypt(crypt *driver.Crypt) *AbortTransaction {
+	if at == nil {
+		at = new(AbortTransaction)
+	}
+
+	at.crypt = crypt
 	return at
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/aggregate.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/aggregate.go
@@ -44,6 +44,7 @@ type Aggregate struct {
 	retry                    *driver.RetryMode
 	selector                 description.ServerSelector
 	writeConcern             *writeconcern.WriteConcern
+	crypt                    *driver.Crypt
 
 	result driver.CursorResponse
 }
@@ -97,6 +98,7 @@ func (a *Aggregate) Execute(ctx context.Context) error {
 		RetryMode:                      a.retry,
 		Selector:                       a.selector,
 		WriteConcern:                   a.writeConcern,
+		Crypt:                          a.crypt,
 		MinimumWriteConcernWireVersion: 5,
 	}.Execute(ctx, nil)
 
@@ -339,5 +341,15 @@ func (a *Aggregate) Retry(retry driver.RetryMode) *Aggregate {
 	}
 
 	a.retry = &retry
+	return a
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (a *Aggregate) Crypt(crypt *driver.Crypt) *Aggregate {
+	if a == nil {
+		a = new(Aggregate)
+	}
+
+	a.crypt = crypt
 	return a
 }

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/command.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/command.go
@@ -29,6 +29,7 @@ type Command struct {
 	result         bsoncore.Document
 	srvr           driver.Server
 	desc           description.Server
+	crypt          *driver.Crypt
 }
 
 // NewCommand constructs and returns a new Command.
@@ -70,6 +71,7 @@ func (c *Command) Execute(ctx context.Context) error {
 		Deployment:     c.deployment,
 		ReadPreference: c.readPreference,
 		Selector:       c.selector,
+		Crypt:          c.crypt,
 	}.Execute(ctx, nil)
 }
 
@@ -160,5 +162,15 @@ func (c *Command) ServerSelector(selector description.ServerSelector) *Command {
 	}
 
 	c.selector = selector
+	return c
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (c *Command) Crypt(crypt *driver.Crypt) *Command {
+	if c == nil {
+		c = new(Command)
+	}
+
+	c.crypt = crypt
 	return c
 }

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/commit_transaction.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/commit_transaction.go
@@ -27,6 +27,7 @@ type CommitTransaction struct {
 	session       *session.Client
 	clock         *session.ClusterClock
 	monitor       *event.CommandMonitor
+	crypt         *driver.Crypt
 	database      string
 	deployment    driver.Deployment
 	selector      description.ServerSelector
@@ -58,6 +59,7 @@ func (ct *CommitTransaction) Execute(ctx context.Context) error {
 		Client:            ct.session,
 		Clock:             ct.clock,
 		CommandMonitor:    ct.monitor,
+		Crypt:             ct.crypt,
 		Database:          ct.database,
 		Deployment:        ct.deployment,
 		Selector:          ct.selector,
@@ -125,6 +127,16 @@ func (ct *CommitTransaction) CommandMonitor(monitor *event.CommandMonitor) *Comm
 	}
 
 	ct.monitor = monitor
+	return ct
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (ct *CommitTransaction) Crypt(crypt *driver.Crypt) *CommitTransaction {
+	if ct == nil {
+		ct = new(CommitTransaction)
+	}
+
+	ct.crypt = crypt
 	return ct
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/count.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/count.go
@@ -30,6 +30,7 @@ type Count struct {
 	clock          *session.ClusterClock
 	collection     string
 	monitor        *event.CommandMonitor
+	crypt          *driver.Crypt
 	database       string
 	deployment     driver.Deployment
 	readConcern    *readconcern.ReadConcern
@@ -91,6 +92,7 @@ func (c *Count) Execute(ctx context.Context) error {
 		Client:            c.session,
 		Clock:             c.clock,
 		CommandMonitor:    c.monitor,
+		Crypt:             c.crypt,
 		Database:          c.database,
 		Deployment:        c.deployment,
 		ReadConcern:       c.readConcern,
@@ -168,6 +170,16 @@ func (c *Count) CommandMonitor(monitor *event.CommandMonitor) *Count {
 	}
 
 	c.monitor = monitor
+	return c
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (c *Count) Crypt(crypt *driver.Crypt) *Count {
+	if c == nil {
+		c = new(Count)
+	}
+
+	c.crypt = crypt
 	return c
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/createIndexes.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/createIndexes.go
@@ -28,6 +28,7 @@ type CreateIndexes struct {
 	clock      *session.ClusterClock
 	collection string
 	monitor    *event.CommandMonitor
+	crypt      *driver.Crypt
 	database   string
 	deployment driver.Deployment
 	selector   description.ServerSelector
@@ -102,6 +103,7 @@ func (ci *CreateIndexes) Execute(ctx context.Context) error {
 		Client:            ci.session,
 		Clock:             ci.clock,
 		CommandMonitor:    ci.monitor,
+		Crypt:             ci.crypt,
 		Database:          ci.database,
 		Deployment:        ci.deployment,
 		Selector:          ci.selector,
@@ -177,6 +179,16 @@ func (ci *CreateIndexes) CommandMonitor(monitor *event.CommandMonitor) *CreateIn
 	}
 
 	ci.monitor = monitor
+	return ci
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (ci *CreateIndexes) Crypt(crypt *driver.Crypt) *CreateIndexes {
+	if ci == nil {
+		ci = new(CreateIndexes)
+	}
+
+	ci.crypt = crypt
 	return ci
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/delete.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/delete.go
@@ -29,6 +29,7 @@ type Delete struct {
 	clock        *session.ClusterClock
 	collection   string
 	monitor      *event.CommandMonitor
+	crypt        *driver.Crypt
 	database     string
 	deployment   driver.Deployment
 	selector     description.ServerSelector
@@ -97,6 +98,7 @@ func (d *Delete) Execute(ctx context.Context) error {
 		Client:            d.session,
 		Clock:             d.clock,
 		CommandMonitor:    d.monitor,
+		Crypt:             d.crypt,
 		Database:          d.database,
 		Deployment:        d.deployment,
 		Selector:          d.selector,
@@ -173,6 +175,16 @@ func (d *Delete) CommandMonitor(monitor *event.CommandMonitor) *Delete {
 	}
 
 	d.monitor = monitor
+	return d
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (d *Delete) Crypt(crypt *driver.Crypt) *Delete {
+	if d == nil {
+		d = new(Delete)
+	}
+
+	d.crypt = crypt
 	return d
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/distinct.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/distinct.go
@@ -31,6 +31,7 @@ type Distinct struct {
 	clock          *session.ClusterClock
 	collection     string
 	monitor        *event.CommandMonitor
+	crypt          *driver.Crypt
 	database       string
 	deployment     driver.Deployment
 	readConcern    *readconcern.ReadConcern
@@ -91,6 +92,7 @@ func (d *Distinct) Execute(ctx context.Context) error {
 		Client:            d.session,
 		Clock:             d.clock,
 		CommandMonitor:    d.monitor,
+		Crypt:             d.crypt,
 		Database:          d.database,
 		Deployment:        d.deployment,
 		ReadConcern:       d.readConcern,
@@ -197,6 +199,16 @@ func (d *Distinct) CommandMonitor(monitor *event.CommandMonitor) *Distinct {
 	}
 
 	d.monitor = monitor
+	return d
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (d *Distinct) Crypt(crypt *driver.Crypt) *Distinct {
+	if d == nil {
+		d = new(Distinct)
+	}
+
+	d.crypt = crypt
 	return d
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/drop_collection.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/drop_collection.go
@@ -27,6 +27,7 @@ type DropCollection struct {
 	clock        *session.ClusterClock
 	collection   string
 	monitor      *event.CommandMonitor
+	crypt        *driver.Crypt
 	database     string
 	deployment   driver.Deployment
 	selector     description.ServerSelector
@@ -92,6 +93,7 @@ func (dc *DropCollection) Execute(ctx context.Context) error {
 		Client:            dc.session,
 		Clock:             dc.clock,
 		CommandMonitor:    dc.monitor,
+		Crypt:             dc.crypt,
 		Database:          dc.database,
 		Deployment:        dc.deployment,
 		Selector:          dc.selector,
@@ -142,6 +144,16 @@ func (dc *DropCollection) CommandMonitor(monitor *event.CommandMonitor) *DropCol
 	}
 
 	dc.monitor = monitor
+	return dc
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (dc *DropCollection) Crypt(crypt *driver.Crypt) *DropCollection {
+	if dc == nil {
+		dc = new(DropCollection)
+	}
+
+	dc.crypt = crypt
 	return dc
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/drop_database.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/drop_database.go
@@ -26,6 +26,7 @@ type DropDatabase struct {
 	session      *session.Client
 	clock        *session.ClusterClock
 	monitor      *event.CommandMonitor
+	crypt        *driver.Crypt
 	database     string
 	deployment   driver.Deployment
 	selector     description.ServerSelector
@@ -83,6 +84,7 @@ func (dd *DropDatabase) Execute(ctx context.Context) error {
 		Client:            dd.session,
 		Clock:             dd.clock,
 		CommandMonitor:    dd.monitor,
+		Crypt:             dd.crypt,
 		Database:          dd.database,
 		Deployment:        dd.deployment,
 		Selector:          dd.selector,
@@ -124,6 +126,16 @@ func (dd *DropDatabase) CommandMonitor(monitor *event.CommandMonitor) *DropDatab
 	}
 
 	dd.monitor = monitor
+	return dd
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (dd *DropDatabase) Crypt(crypt *driver.Crypt) *DropDatabase {
+	if dd == nil {
+		dd = new(DropDatabase)
+	}
+
+	dd.crypt = crypt
 	return dd
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/drop_indexes.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/drop_indexes.go
@@ -29,6 +29,7 @@ type DropIndexes struct {
 	clock        *session.ClusterClock
 	collection   string
 	monitor      *event.CommandMonitor
+	crypt        *driver.Crypt
 	database     string
 	deployment   driver.Deployment
 	selector     description.ServerSelector
@@ -88,6 +89,7 @@ func (di *DropIndexes) Execute(ctx context.Context) error {
 		Client:            di.session,
 		Clock:             di.clock,
 		CommandMonitor:    di.monitor,
+		Crypt:             di.crypt,
 		Database:          di.database,
 		Deployment:        di.deployment,
 		Selector:          di.selector,
@@ -165,6 +167,16 @@ func (di *DropIndexes) CommandMonitor(monitor *event.CommandMonitor) *DropIndexe
 	}
 
 	di.monitor = monitor
+	return di
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (di *DropIndexes) Crypt(crypt *driver.Crypt) *DropIndexes {
+	if di == nil {
+		di = new(DropIndexes)
+	}
+
+	di.crypt = crypt
 	return di
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/end_sessions.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/end_sessions.go
@@ -25,6 +25,7 @@ type EndSessions struct {
 	session    *session.Client
 	clock      *session.ClusterClock
 	monitor    *event.CommandMonitor
+	crypt      *driver.Crypt
 	database   string
 	deployment driver.Deployment
 	selector   description.ServerSelector
@@ -54,6 +55,7 @@ func (es *EndSessions) Execute(ctx context.Context) error {
 		Client:            es.session,
 		Clock:             es.clock,
 		CommandMonitor:    es.monitor,
+		Crypt:             es.crypt,
 		Database:          es.database,
 		Deployment:        es.deployment,
 		Selector:          es.selector,
@@ -105,6 +107,16 @@ func (es *EndSessions) CommandMonitor(monitor *event.CommandMonitor) *EndSession
 	}
 
 	es.monitor = monitor
+	return es
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (es *EndSessions) Crypt(crypt *driver.Crypt) *EndSessions {
+	if es == nil {
+		es = new(EndSessions)
+	}
+
+	es.crypt = crypt
 	return es
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/find.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/find.go
@@ -49,6 +49,7 @@ type Find struct {
 	clock               *session.ClusterClock
 	collection          string
 	monitor             *event.CommandMonitor
+	crypt               *driver.Crypt
 	database            string
 	deployment          driver.Deployment
 	readConcern         *readconcern.ReadConcern
@@ -90,6 +91,7 @@ func (f *Find) Execute(ctx context.Context) error {
 		Client:            f.session,
 		Clock:             f.clock,
 		CommandMonitor:    f.monitor,
+		Crypt:             f.crypt,
 		Database:          f.database,
 		Deployment:        f.deployment,
 		ReadConcern:       f.readConcern,
@@ -418,6 +420,16 @@ func (f *Find) CommandMonitor(monitor *event.CommandMonitor) *Find {
 	}
 
 	f.monitor = monitor
+	return f
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (f *Find) Crypt(crypt *driver.Crypt) *Find {
+	if f == nil {
+		f = new(Find)
+	}
+
+	f.crypt = crypt
 	return f
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/find_and_modify.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/find_and_modify.go
@@ -44,6 +44,7 @@ type FindAndModify struct {
 	selector                 description.ServerSelector
 	writeConcern             *writeconcern.WriteConcern
 	retry                    *driver.RetryMode
+	crypt                    *driver.Crypt
 
 	result FindAndModifyResult
 }
@@ -131,6 +132,7 @@ func (fam *FindAndModify) Execute(ctx context.Context) error {
 		Deployment:     fam.deployment,
 		Selector:       fam.selector,
 		WriteConcern:   fam.writeConcern,
+		Crypt:          fam.crypt,
 	}.Execute(ctx, nil)
 
 }
@@ -390,5 +392,15 @@ func (fam *FindAndModify) Retry(retry driver.RetryMode) *FindAndModify {
 	}
 
 	fam.retry = &retry
+	return fam
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (fam *FindAndModify) Crypt(crypt *driver.Crypt) *FindAndModify {
+	if fam == nil {
+		fam = new(FindAndModify)
+	}
+
+	fam.crypt = crypt
 	return fam
 }

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/insert.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/insert.go
@@ -30,6 +30,7 @@ type Insert struct {
 	clock                    *session.ClusterClock
 	collection               string
 	monitor                  *event.CommandMonitor
+	crypt                    *driver.Crypt
 	database                 string
 	deployment               driver.Deployment
 	selector                 description.ServerSelector
@@ -98,6 +99,7 @@ func (i *Insert) Execute(ctx context.Context) error {
 		Client:            i.session,
 		Clock:             i.clock,
 		CommandMonitor:    i.monitor,
+		Crypt:             i.crypt,
 		Database:          i.database,
 		Deployment:        i.deployment,
 		Selector:          i.selector,
@@ -187,6 +189,16 @@ func (i *Insert) CommandMonitor(monitor *event.CommandMonitor) *Insert {
 	}
 
 	i.monitor = monitor
+	return i
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (i *Insert) Crypt(crypt *driver.Crypt) *Insert {
+	if i == nil {
+		i = new(Insert)
+	}
+
+	i.crypt = crypt
 	return i
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/listDatabases.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/listDatabases.go
@@ -34,6 +34,7 @@ type ListDatabases struct {
 	readPreference *readpref.ReadPref
 	retry          *driver.RetryMode
 	selector       description.ServerSelector
+	crypt          *driver.Crypt
 
 	result ListDatabasesResult
 }
@@ -168,6 +169,7 @@ func (ld *ListDatabases) Execute(ctx context.Context) error {
 		RetryMode:      ld.retry,
 		Type:           driver.Read,
 		Selector:       ld.selector,
+		Crypt:          ld.crypt,
 	}.Execute(ctx, nil)
 
 }
@@ -284,5 +286,15 @@ func (ld *ListDatabases) Retry(retry driver.RetryMode) *ListDatabases {
 	}
 
 	ld.retry = &retry
+	return ld
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (ld *ListDatabases) Crypt(crypt *driver.Crypt) *ListDatabases {
+	if ld == nil {
+		ld = new(ListDatabases)
+	}
+
+	ld.crypt = crypt
 	return ld
 }

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/list_collections.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/list_collections.go
@@ -27,6 +27,7 @@ type ListCollections struct {
 	session        *session.Client
 	clock          *session.ClusterClock
 	monitor        *event.CommandMonitor
+	crypt          *driver.Crypt
 	database       string
 	deployment     driver.Deployment
 	readPreference *readpref.ReadPref
@@ -75,6 +76,7 @@ func (lc *ListCollections) Execute(ctx context.Context) error {
 		Client:            lc.session,
 		Clock:             lc.clock,
 		CommandMonitor:    lc.monitor,
+		Crypt:             lc.crypt,
 		Database:          lc.database,
 		Deployment:        lc.deployment,
 		ReadPreference:    lc.readPreference,
@@ -143,6 +145,16 @@ func (lc *ListCollections) CommandMonitor(monitor *event.CommandMonitor) *ListCo
 	}
 
 	lc.monitor = monitor
+	return lc
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (lc *ListCollections) Crypt(crypt *driver.Crypt) *ListCollections {
+	if lc == nil {
+		lc = new(ListCollections)
+	}
+
+	lc.crypt = crypt
 	return lc
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/list_indexes.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/list_indexes.go
@@ -31,6 +31,7 @@ type ListIndexes struct {
 	deployment driver.Deployment
 	selector   description.ServerSelector
 	retry      *driver.RetryMode
+	crypt      *driver.Crypt
 
 	result driver.CursorResponse
 }
@@ -73,6 +74,7 @@ func (li *ListIndexes) Execute(ctx context.Context) error {
 		Database:       li.database,
 		Deployment:     li.deployment,
 		Selector:       li.selector,
+		Crypt:          li.crypt,
 		Legacy:         driver.LegacyListIndexes,
 		RetryMode:      li.retry,
 		Type:           driver.Read,
@@ -196,5 +198,15 @@ func (li *ListIndexes) Retry(retry driver.RetryMode) *ListIndexes {
 	}
 
 	li.retry = &retry
+	return li
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (li *ListIndexes) Crypt(crypt *driver.Crypt) *ListIndexes {
+	if li == nil {
+		li = new(ListIndexes)
+	}
+
+	li.crypt = crypt
 	return li
 }

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/update.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation/update.go
@@ -37,6 +37,7 @@ type Update struct {
 	writeConcern             *writeconcern.WriteConcern
 	retry                    *driver.RetryMode
 	result                   UpdateResult
+	crypt                    *driver.Crypt
 }
 
 // Upsert contains the information for an upsert in an Update operation.
@@ -150,6 +151,7 @@ func (u *Update) Execute(ctx context.Context) error {
 		Deployment:        u.deployment,
 		Selector:          u.selector,
 		WriteConcern:      u.writeConcern,
+		Crypt:             u.crypt,
 	}.Execute(ctx, nil)
 
 }
@@ -291,5 +293,15 @@ func (u *Update) Retry(retry driver.RetryMode) *Update {
 	}
 
 	u.retry = &retry
+	return u
+}
+
+// Crypt sets the Crypt object to use for automatic encryption and decryption.
+func (u *Update) Crypt(crypt *driver.Crypt) *Update {
+	if u == nil {
+		u = new(Update)
+	}
+
+	u.crypt = crypt
 	return u
 }

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation_legacy.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/operation_legacy.go
@@ -107,8 +107,6 @@ func (op Operation) createLegacyFindWireMessage(dst []byte, desc description.Sel
 			optsElems = bsoncore.AppendValueElement(optsElems, "$hint", elem.Value())
 		case "comment":
 			optsElems = bsoncore.AppendValueElement(optsElems, "$comment", elem.Value())
-		case "maxScan":
-			optsElems = bsoncore.AppendValueElement(optsElems, "$maxScan", elem.Value())
 		case "max":
 			optsElems = bsoncore.AppendValueElement(optsElems, "$max", elem.Value())
 		case "min":
@@ -141,7 +139,7 @@ func (op Operation) createLegacyFindWireMessage(dst []byte, desc description.Sel
 			flags |= wiremessage.TailableCursor
 		case "awaitData":
 			flags |= wiremessage.AwaitData
-		case "oplogReply":
+		case "oplogReplay":
 			flags |= wiremessage.OplogReplay
 		case "noCursorTimeout":
 			flags |= wiremessage.NoCursorTimeout
@@ -309,7 +307,7 @@ func (op Operation) legacyKillCursors(ctx context.Context, dst []byte, srvr Serv
 
 	ridx, response := bsoncore.AppendDocumentStart(nil)
 	response = bsoncore.AppendInt32Element(response, "ok", 1)
-	response = bsoncore.AppendArrayElement(response, "cursorsKilled", startedInfo.cmd.Lookup("cursors").Array())
+	response = bsoncore.AppendArrayElement(response, "cursorsUnknown", startedInfo.cmd.Lookup("cursors").Array())
 	response, _ = bsoncore.AppendDocumentEnd(response, ridx)
 
 	finishedInfo.response = response
@@ -560,8 +558,12 @@ func (op Operation) createLegacyListIndexesWiremessage(dst []byte, desc descript
 		switch elem.Key() {
 		case "listIndexes":
 			filterCollName = elem.Value().StringValue()
-		case "batchSize":
-			batchSize = elem.Value().Int32()
+		case "cursor":
+			// the batchSize option is embedded in a cursor subdocument
+			cursorDoc := elem.Value().Document()
+			if val, err := cursorDoc.LookupErr("batchSize"); err == nil {
+				batchSize = val.Int32()
+			}
 		case "maxTimeMS":
 			optsElems = bsoncore.AppendValueElement(optsElems, "$maxTimeMS", elem.Value())
 		}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/topology/connection.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/topology/connection.go
@@ -37,7 +37,7 @@ type connection struct {
 	nc               net.Conn // When nil, the connection is closed.
 	addr             address.Address
 	idleTimeout      time.Duration
-	idleDeadline     time.Time
+	idleDeadline     atomic.Value // Stores a time.Time
 	lifetimeDeadline time.Time
 	readTimeout      time.Duration
 	writeTimeout     time.Duration
@@ -45,6 +45,9 @@ type connection struct {
 	compressor       wiremessage.CompressorID
 	zliblevel        int
 	connected        int32 // must be accessed using the sync/atomic package
+	connectDone      chan struct{}
+	connectErr       error
+	config           *connectionConfig
 
 	// pool related fields
 	pool       *pool
@@ -52,25 +55,11 @@ type connection struct {
 	generation uint64
 }
 
-// newConnection handles the creation of a connection. It will dial, configure TLS, and perform
-// initialization handshakes.
+// newConnection handles the creation of a connection. It does not connect the connection.
 func newConnection(ctx context.Context, addr address.Address, opts ...ConnectionOption) (*connection, error) {
 	cfg, err := newConnectionConfig(opts...)
 	if err != nil {
 		return nil, err
-	}
-
-	nc, err := cfg.dialer.DialContext(ctx, addr.Network(), addr.String())
-	if err != nil {
-		return nil, ConnectionError{Wrapped: err, init: true}
-	}
-
-	if cfg.tlsConfig != nil {
-		tlsConfig := cfg.tlsConfig.Clone()
-		nc, err = configureTLS(ctx, nc, addr, tlsConfig)
-		if err != nil {
-			return nil, ConnectionError{Wrapped: err, init: true}
-		}
 	}
 
 	var lifetimeDeadline time.Time
@@ -82,32 +71,65 @@ func newConnection(ctx context.Context, addr address.Address, opts ...Connection
 
 	c := &connection{
 		id:               id,
-		nc:               nc,
 		addr:             addr,
 		idleTimeout:      cfg.idleTimeout,
 		lifetimeDeadline: lifetimeDeadline,
 		readTimeout:      cfg.readTimeout,
 		writeTimeout:     cfg.writeTimeout,
+		connectDone:      make(chan struct{}),
+		config:           cfg,
 	}
-	atomic.StoreInt32(&c.connected, connected)
+	atomic.StoreInt32(&c.connected, initialized)
+
+	return c, nil
+}
+
+// connect handles the I/O for a connection. It will dial, configure TLS, and perform
+// initialization handshakes.
+func (c *connection) connect(ctx context.Context) {
+
+	if !atomic.CompareAndSwapInt32(&c.connected, initialized, connected) {
+		return
+	}
+	defer close(c.connectDone)
+
+	var err error
+	c.nc, err = c.config.dialer.DialContext(ctx, c.addr.Network(), c.addr.String())
+	if err != nil {
+		atomic.StoreInt32(&c.connected, disconnected)
+		c.connectErr = ConnectionError{Wrapped: err, init: true}
+		return
+	}
+
+	if c.config.tlsConfig != nil {
+		tlsConfig := c.config.tlsConfig.Clone()
+		c.nc, err = configureTLS(ctx, c.nc, c.addr, tlsConfig)
+		if err != nil {
+			atomic.StoreInt32(&c.connected, disconnected)
+			c.connectErr = ConnectionError{Wrapped: err, init: true}
+			return
+		}
+	}
 
 	c.bumpIdleDeadline()
 
 	// running isMaster and authentication is handled by a handshaker on the configuration instance.
-	if cfg.handshaker != nil {
-		c.desc, err = cfg.handshaker.Handshake(ctx, c.addr, initConnection{c})
+	if c.config.handshaker != nil {
+		c.desc, err = c.config.handshaker.Handshake(ctx, c.addr, initConnection{c})
 		if err != nil {
 			if c.nc != nil {
 				_ = c.nc.Close()
 			}
-			return nil, ConnectionError{Wrapped: err, init: true}
+			atomic.StoreInt32(&c.connected, disconnected)
+			c.connectErr = ConnectionError{Wrapped: err, init: true}
+			return
 		}
-		if cfg.descCallback != nil {
-			cfg.descCallback(c.desc)
+		if c.config.descCallback != nil {
+			c.config.descCallback(c.desc)
 		}
 		if len(c.desc.Compression) > 0 {
 		clientMethodLoop:
-			for _, method := range cfg.compressors {
+			for _, method := range c.config.compressors {
 				for _, serverMethod := range c.desc.Compression {
 					if method != serverMethod {
 						continue
@@ -119,8 +141,8 @@ func newConnection(ctx context.Context, addr address.Address, opts ...Connection
 					case "zlib":
 						c.compressor = wiremessage.CompressorZLib
 						c.zliblevel = wiremessage.DefaultZlibLevel
-						if cfg.zlibLevel != nil {
-							c.zliblevel = *cfg.zlibLevel
+						if c.config.zlibLevel != nil {
+							c.zliblevel = *c.config.zlibLevel
 						}
 					}
 					break clientMethodLoop
@@ -128,7 +150,13 @@ func newConnection(ctx context.Context, addr address.Address, opts ...Connection
 			}
 		}
 	}
-	return c, nil
+}
+
+func (c *connection) wait() error {
+	if c.connectDone != nil {
+		<-c.connectDone
+	}
+	return c.connectErr
 }
 
 func (c *connection) writeWireMessage(ctx context.Context, wm []byte) error {
@@ -234,7 +262,11 @@ func (c *connection) close() error {
 		return nil
 	}
 	if c.pool == nil {
-		err := c.nc.Close()
+		var err error
+
+		if c.nc != nil {
+			err = c.nc.Close()
+		}
 		atomic.StoreInt32(&c.connected, disconnected)
 		return err
 	}
@@ -243,7 +275,8 @@ func (c *connection) close() error {
 
 func (c *connection) expired() bool {
 	now := time.Now()
-	if !c.idleDeadline.IsZero() && now.After(c.idleDeadline) {
+	idleDeadline, ok := c.idleDeadline.Load().(time.Time)
+	if ok && now.After(idleDeadline) {
 		return true
 	}
 
@@ -256,7 +289,7 @@ func (c *connection) expired() bool {
 
 func (c *connection) bumpIdleDeadline() {
 	if c.idleTimeout > 0 {
-		c.idleDeadline = time.Now().Add(c.idleTimeout)
+		c.idleDeadline.Store(time.Now().Add(c.idleTimeout))
 	}
 }
 

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/topology/server.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/topology/server.go
@@ -58,6 +58,7 @@ const (
 	disconnecting
 	connected
 	connecting
+	initialized
 )
 
 func connectionStateString(state int32) string {
@@ -70,6 +71,8 @@ func connectionStateString(state int32) string {
 		return "Connected"
 	case 3:
 		return "Connecting"
+	case 4:
+		return "Initialized"
 	}
 
 	return ""
@@ -493,6 +496,10 @@ func (s *Server) heartbeat(conn *connection) (description.Server, *connection) {
 			}))
 
 			conn, err = newConnection(ctx, s.address, opts...)
+
+			conn.connect(ctx)
+
+			err := conn.wait()
 			if err == nil {
 				descPtr = &conn.desc
 			}

--- a/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/topology/topology.go
+++ b/vendor/go.mongodb.org/mongo-driver/x/mongo/driver/topology/topology.go
@@ -25,7 +25,6 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/address"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/dns"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/session"
 )
 
 // ErrSubscribeAfterClosed is returned when a user attempts to subscribe to a
@@ -72,8 +71,6 @@ type Topology struct {
 
 	fsm *fsm
 
-	SessionPool *session.Pool
-
 	// This should really be encapsulated into it's own type. This will likely
 	// require a redesign so we can share a minimum of data between the
 	// subscribers and the topology.
@@ -90,6 +87,9 @@ type Topology struct {
 	serversClosed bool
 	servers       map[address.Address]*Server
 }
+
+var _ driver.Deployment = &Topology{}
+var _ driver.Subscriber = &Topology{}
 
 // New creates a new topology.
 func New(opts ...Option) (*Topology, error) {
@@ -136,6 +136,9 @@ func (t *Topology) Connect() error {
 		addr := address.Address(a).Canonicalize()
 		t.fsm.Servers = append(t.fsm.Servers, description.Server{Addr: addr})
 		err = t.addServer(addr)
+		if err != nil {
+			return err
+		}
 	}
 	t.serversLock.Unlock()
 
@@ -147,11 +150,7 @@ func (t *Topology) Connect() error {
 	t.subscriptionsClosed = false // explicitly set in case topology was disconnected and then reconnected
 
 	atomic.StoreInt32(&t.connectionstate, connected)
-
-	// After connection, make a subscription to keep the pool updated
-	sub, err := t.Subscribe()
-	t.SessionPool = session.NewPool(sub.C)
-	return err
+	return nil
 }
 
 // Disconnect closes the topology. It stops the monitoring thread and
@@ -211,7 +210,8 @@ func (t *Topology) Kind() description.TopologyKind { return t.Description().Kind
 // Subscribe returns a Subscription on which all updated description.Topologys
 // will be sent. The channel of the subscription will have a buffer size of one,
 // and will be pre-populated with the current description.Topology.
-func (t *Topology) Subscribe() (*Subscription, error) {
+// Subscribe implements the driver.Subscriber interface.
+func (t *Topology) Subscribe() (*driver.Subscription, error) {
 	if atomic.LoadInt32(&t.connectionstate) != connected {
 		return nil, errors.New("cannot subscribe to Topology that is not connected")
 	}
@@ -231,11 +231,30 @@ func (t *Topology) Subscribe() (*Subscription, error) {
 	t.subscribers[id] = ch
 	t.currentSubscriberID++
 
-	return &Subscription{
-		C:  ch,
-		t:  t,
-		id: id,
+	return &driver.Subscription{
+		Updates: ch,
+		ID:      id,
 	}, nil
+}
+
+// Unsubscribe unsubscribes the given subscription from the topology and closes the subscription channel.
+// Unsubscribe implements the driver.Subscriber interface.
+func (t *Topology) Unsubscribe(sub *driver.Subscription) error {
+	t.subLock.Lock()
+	defer t.subLock.Unlock()
+
+	if t.subscriptionsClosed {
+		return nil
+	}
+
+	ch, ok := t.subscribers[sub.ID]
+	if !ok {
+		return nil
+	}
+
+	close(ch)
+	delete(t.subscribers, sub.ID)
+	return nil
 }
 
 // RequestImmediateCheck will send heartbeats to all the servers in the
@@ -280,10 +299,10 @@ func (t *Topology) SelectServer(ctx context.Context, ss description.ServerSelect
 	if err != nil {
 		return nil, err
 	}
-	defer sub.Unsubscribe()
+	defer t.Unsubscribe(sub)
 
 	for {
-		suitable, err := t.selectServer(ctx, sub.C, ss, ssTimeoutCh)
+		suitable, err := t.selectServer(ctx, sub.Updates, ss, ssTimeoutCh)
 		if err != nil {
 			return nil, err
 		}
@@ -323,10 +342,10 @@ func (t *Topology) SelectServerLegacy(ctx context.Context, ss description.Server
 	if err != nil {
 		return nil, err
 	}
-	defer sub.Unsubscribe()
+	defer t.Unsubscribe(sub)
 
 	for {
-		suitable, err := t.selectServer(ctx, sub.C, ss, ssTimeoutCh)
+		suitable, err := t.selectServer(ctx, sub.Updates, ss, ssTimeoutCh)
 		if err != nil {
 			return nil, err
 		}
@@ -591,36 +610,10 @@ func (t *Topology) addServer(addr address.Address) error {
 func (t *Topology) String() string {
 	desc := t.Description()
 	str := fmt.Sprintf("Type: %s\nServers:\n", desc.Kind)
+	t.serversLock.Lock()
+	defer t.serversLock.Unlock()
 	for _, s := range t.servers {
 		str += s.String() + "\n"
 	}
 	return str
-}
-
-// Subscription is a subscription to updates to the description of the Topology that created this
-// Subscription.
-type Subscription struct {
-	C  <-chan description.Topology
-	t  *Topology
-	id uint64
-}
-
-// Unsubscribe unsubscribes this Subscription from updates and closes the
-// subscription channel.
-func (s *Subscription) Unsubscribe() error {
-	s.t.subLock.Lock()
-	defer s.t.subLock.Unlock()
-	if s.t.subscriptionsClosed {
-		return nil
-	}
-
-	ch, ok := s.t.subscribers[s.id]
-	if !ok {
-		return nil
-	}
-
-	close(ch)
-	delete(s.t.subscribers, s.id)
-
-	return nil
 }


### PR DESCRIPTION
For now, I kept the `NewBSONSource()` and `NewBufferlessBSONSource()` function signatures the same. This is because changing them would require changes to mongo-tools. I think I'll clean this up by adding MaxBSONSize as a parameter to those functions, and removing `SetMaxBSONSize()`.