### PR TITLE
MGOMIRROR-292 No socket timeout by default

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -50,9 +50,6 @@ const (
 	DefaultTestPort = "33333"
 )
 
-// Hard coded socket timeout in seconds
-const SocketTimeout = 600
-
 const (
 	ErrLostConnection     = "lost connection to server"
 	ErrNoReachableServers = "no reachable servers"
@@ -282,10 +279,9 @@ func configureClient(opts options.ToolOptions) (*mongo.Client, error) {
 	if err := uriOpts.Validate(); err != nil {
 		return nil, fmt.Errorf("error parsing options from URI: %v", err)
 	}
-	timeout := time.Duration(opts.Timeout) * time.Second
 
-	clientopt.SetConnectTimeout(timeout)
-	clientopt.SetSocketTimeout(SocketTimeout * time.Second)
+	clientopt.SetConnectTimeout(time.Duration(opts.Timeout) * time.Second)
+	clientopt.SetSocketTimeout(time.Duration(opts.SocketTimeout) * time.Second)
 	if opts.Connection.ServerSelectionTimeout > 0 {
 		clientopt.SetServerSelectionTimeout(time.Duration(opts.Connection.ServerSelectionTimeout) * time.Second)
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -140,6 +140,7 @@ type Connection struct {
 	Port string `long:"port" value-name:"<port>" description:"server port (can also use --host hostname:port)"`
 
 	Timeout                int `long:"dialTimeout" default:"3" hidden:"true" description:"dial timeout in seconds"`
+	SocketTimeout          int `long:"socketTimeout" default:"0" hidden:"true" description:"socket timeout in seconds (0 for no timeout)"`
 	TCPKeepAliveSeconds    int `long:"TCPKeepAliveSeconds" default:"30" hidden:"true" description:"seconds between TCP keep alives"`
 	ServerSelectionTimeout int `long:"serverSelectionTimeout" hidden:"true" description:"seconds to wait for server selection; 0 means driver default"`
 }
@@ -510,8 +511,11 @@ func (opts *ToolOptions) setOptionsFromURI(cs connstring.ConnString) error {
 			return fmt.Errorf(IncompatibleArgsErrorFormat, "--port")
 		case opts.Connection.Timeout != 3:
 			return fmt.Errorf(IncompatibleArgsErrorFormat, "--dialTimeout")
+		case opts.Connection.SocketTimeout != 0:
+			return fmt.Errorf(IncompatibleArgsErrorFormat, "--socketTimeout")
 		}
 		opts.Connection.Timeout = int(cs.ConnectTimeout / time.Millisecond)
+		opts.Connection.SocketTimeout = int(cs.SocketTimeout / time.Millisecond)
 	}
 
 	if opts.enabledOptions.Auth {

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -215,12 +215,14 @@ func TestParseAndSetOptions(t *testing.T) {
 				Name: "connection fields set",
 				CS: connstring.ConnString{
 					ConnectTimeout: time.Duration(100) * time.Millisecond,
+					SocketTimeout:  time.Duration(200) * time.Millisecond,
 				},
 				OptsIn: &ToolOptions{
 					General:   &General{},
 					Verbosity: &Verbosity{},
 					Connection: &Connection{
-						Timeout: 3,
+						Timeout:       3,
+						SocketTimeout: 0,
 					},
 					URI:            &URI{},
 					SSL:            &SSL{},
@@ -233,7 +235,8 @@ func TestParseAndSetOptions(t *testing.T) {
 					General:   &General{},
 					Verbosity: &Verbosity{},
 					Connection: &Connection{
-						Timeout: 100,
+						Timeout:       100,
+						SocketTimeout: 200,
 					},
 					URI:            &URI{},
 					SSL:            &SSL{},
@@ -401,6 +404,7 @@ func TestParseAndSetOptions(t *testing.T) {
 				}
 
 				So(testCase.OptsIn.Connection.Timeout, ShouldResemble, testCase.OptsExpected.Connection.Timeout)
+				So(testCase.OptsIn.Connection.SocketTimeout, ShouldResemble, testCase.OptsExpected.Connection.SocketTimeout)
 				So(testCase.OptsIn.Username, ShouldResemble, testCase.OptsExpected.Username)
 				So(testCase.OptsIn.Password, ShouldResemble, testCase.OptsExpected.Password)
 				So(testCase.OptsIn.Source, ShouldResemble, testCase.OptsExpected.Source)
@@ -428,6 +432,7 @@ func TestHiddenOptionsDefaults(t *testing.T) {
 		Convey("hidden options should have expected values", func() {
 			So(opts.MaxProcs, ShouldEqual, runtime.NumCPU())
 			So(opts.Timeout, ShouldEqual, 3)
+			So(opts.SocketTimeout, ShouldEqual, 0)
 		})
 	})
 


### PR DESCRIPTION
This sets the default socket timeout to 0 (forever), which better
matches the old mgo-based tools.  It adds a hidden option to set it to
something else, if needed.