### PR TITLE
TOOLS-1826 TOOLS-2403 Fix demux deadlock and panic

### DIFF
--- a/archive/demultiplexer.go
+++ b/archive/demultiplexer.go
@@ -248,6 +248,7 @@ type RegularCollectionReceiver struct {
 	partialReadBuf   []byte
 	hash             hash.Hash64
 	closeOnce        sync.Once
+	endOnce          sync.Once
 	openOnce         sync.Once
 	err              error
 }
@@ -374,7 +375,10 @@ func (receiver *RegularCollectionReceiver) Close() error {
 // it waits on the readBufChan, which is closed by the reader-side Close()
 // method.
 func (receiver *RegularCollectionReceiver) End() {
-	close(receiver.readLenChan)
+	// To keep this idempotent, close the channel only once.
+	receiver.endOnce.Do(func() {
+		close(receiver.readLenChan)
+	})
 	<-receiver.readBufChan
 }
 

--- a/archive/demultiplexer.go
+++ b/archive/demultiplexer.go
@@ -22,10 +22,10 @@ import (
 )
 
 // DemuxOut is a Demultiplexer output consumer
-// The Write() and Close() occur in the same thread as the Demultiplexer runs in.
+// The Write() and End() occur in the same thread as the Demultiplexer runs in.
 type DemuxOut interface {
 	Write([]byte) (int, error)
-	Close() error
+	End()
 	Sum64() (uint64, bool)
 }
 
@@ -145,7 +145,7 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 		if rcr, ok := demux.outs[demux.currentNamespace].(*RegularCollectionReceiver); ok {
 			rcr.err = io.EOF
 		}
-		demux.outs[demux.currentNamespace].Close()
+		demux.outs[demux.currentNamespace].End()
 		demux.NamespaceStatus[demux.currentNamespace] = NamespaceClosed
 		length := int64(demux.lengths[demux.currentNamespace])
 		crcUInt64, ok := demux.outs[demux.currentNamespace].Sum64()
@@ -186,7 +186,7 @@ func (demux *Demultiplexer) End() error {
 			if rcr, ok := demux.outs[ns].(*RegularCollectionReceiver); ok {
 				rcr.err = newError("archive io error")
 			}
-			demux.outs[ns].Close()
+			demux.outs[ns].End()
 		}
 		err = newError(fmt.Sprintf("archive finished but contained files were unfinished (%v)", openNss))
 	} else {
@@ -272,7 +272,6 @@ func (receiver *RegularCollectionReceiver) Read(r []byte) (int, error) {
 	// Since we're the "reader" here, not the "writer" we need to start with a read, in case the chan is closed
 	wLen, ok := <-receiver.readLenChan
 	if !ok {
-		close(receiver.readBufChan)
 		return 0, receiver.err
 	}
 	if wLen > db.MaxBSONSize {
@@ -337,7 +336,17 @@ func (receiver *RegularCollectionReceiver) Write(buf []byte) (int, error) {
 	//  As a writer, we need to write first, so that the reader can properly detect EOF
 	//  Additionally, the reader needs to know the write size, so that it can give us a
 	//  properly sized buffer. Sending the incoming buffersize fills both of these needs.
-	receiver.readLenChan <- len(buf)
+	//  However, it's possible the intent has been closed already so the reader
+	//  won't be reading the channel.  To avoid deadlock, we check for closed
+	//  readBufChan.
+	select {
+	case receiver.readLenChan <- len(buf):
+		// do nothing other than send
+	case <-receiver.readBufChan:
+		// Will only receive this if closed
+		return 0, errInterrupted
+	}
+
 	// Receive from the reader a buffer to put the bytes into
 	readBuf := <-receiver.readBufChan
 	if len(readBuf) < len(buf) {
@@ -354,12 +363,19 @@ func (receiver *RegularCollectionReceiver) Write(buf []byte) (int, error) {
 // cause the RegularCollectionReceiver.Read() to receive EOF
 // Close will get called twice, once in the demultiplexer, and again when the restore goroutine is done with its intent.file
 func (receiver *RegularCollectionReceiver) Close() error {
+	// Close must be idempotent and repeat channel closes panic; only do once.
 	receiver.closeOnce.Do(func() {
-		close(receiver.readLenChan)
-		// make sure that we don't return until any reader has finished
-		<-receiver.readBufChan
+		close(receiver.readBufChan)
 	})
 	return nil
+}
+
+// End signals to any waiting readers that there is nothing more to read, then
+// it waits on the readBufChan, which is closed by the reader-side Close()
+// method.
+func (receiver *RegularCollectionReceiver) End() {
+	close(receiver.readLenChan)
+	<-receiver.readBufChan
 }
 
 // SpecialCollectionCache implements both DemuxOut as well as intents.file
@@ -384,10 +400,15 @@ func (cache *SpecialCollectionCache) Open() error {
 	return nil
 }
 
-// Close is part of the both interfaces, and it does nothing
+// Close is part of the intents.file interface, and does nothing
 func (cache *SpecialCollectionCache) Close() error {
-	cache.Intent.Size = int64(cache.buf.Len())
 	return nil
+}
+
+// End indicates we've read all there is to read, so
+// we update the intent size based on the final length.
+func (cache *SpecialCollectionCache) End() {
+	cache.Intent.Size = int64(cache.buf.Len())
 }
 
 func (cache *SpecialCollectionCache) Read(p []byte) (int, error) {
@@ -431,6 +452,9 @@ func (*MutedCollection) Write(b []byte) (int, error) {
 func (*MutedCollection) Close() error {
 	return nil
 }
+
+// End is part of the DemuxOut interface and does nothing.
+func (*MutedCollection) End() {}
 
 // Open is part of the intents.file interface, and does nothing
 func (*MutedCollection) Open() error {

--- a/archive/parser.go
+++ b/archive/parser.go
@@ -7,11 +7,14 @@
 package archive
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/mongodb/mongo-tools-common/db"
 )
+
+var errInterrupted = errors.New("archive reading interrupted")
 
 // parser.go implements the parsing of the low-level archive format
 // The low level archive format is defined as zero or more blocks
@@ -57,6 +60,11 @@ func newParserError(msg string) error {
 
 // newParserWrappedError creates a parserError with a message as well as an underlying cause error
 func newParserWrappedError(msg string, err error) error {
+	// If parsing was terminated intentionally, pass through that error
+	// instead of a parser error.
+	if err == errInterrupted {
+		return err
+	}
 	return &parserError{
 		Err: err,
 		Msg: msg,


### PR DESCRIPTION
Prior to this commit, the archive demultiplexer receivers implemented
two interfaces, DemuxOut and intent.file, both of which have a Close
method.  While Close was protected with a sync.Once, this was not enough
to prevent problem behavior.

When the RegularCollectionReceiver Write method blocks waiting for a
reader, calling Close (e.g. from the intent side after an error) would
panic.  If the intent side Close is called after all documents in a
block are read, but before EOF is read, a deadlock would occur.

This commit changes the DemuxOut interface to replace the Close method
with a new End method, so that the demux side and the intent side have
distinct terminations and only these are used to signal to the other
side.

NOTE: This is an API breaking change.  Much of it is internal to the
operation of the demultiplexer, but this change does mean that intents
must be closed on error or EOF or the demultiplexer will not terminate.