### PR TITLE
TOOLS-2513 Remove ApplyURI and manually set all client options

### DIFF
--- a/db/buffered_bulk_test.go
+++ b/db/buffered_bulk_test.go
@@ -28,6 +28,7 @@ func TestBufferedBulkInserterInserts(t *testing.T) {
 			Connection: &options.Connection{
 				Port: DefaultTestPort,
 			},
+			URI:  &options.URI{},
 			SSL:  &ssl,
 			Auth: &auth,
 		}

--- a/db/buffered_bulk_test.go
+++ b/db/buffered_bulk_test.go
@@ -32,6 +32,7 @@ func TestBufferedBulkInserterInserts(t *testing.T) {
 			SSL:  &ssl,
 			Auth: &auth,
 		}
+		err := opts.NormalizeOptionsAndURI()
 		provider, err := NewSessionProvider(opts)
 		So(provider, ShouldNotBeNil)
 		So(err, ShouldBeNil)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -63,6 +63,7 @@ func TestNewSessionProvider(t *testing.T) {
 				Connection: &options.Connection{
 					Port: DefaultTestPort,
 				},
+				URI:  &options.URI{},
 				SSL:  &ssl,
 				Auth: &auth,
 			}
@@ -81,6 +82,7 @@ func TestNewSessionProvider(t *testing.T) {
 				Connection: &options.Connection{
 					Port: DefaultTestPort,
 				},
+				URI:  &options.URI{},
 				SSL:  &ssl,
 				Auth: &auth,
 			}
@@ -127,6 +129,7 @@ func TestDatabaseNames(t *testing.T) {
 			Connection: &options.Connection{
 				Port: DefaultTestPort,
 			},
+			URI:  &options.URI{},
 			SSL:  &ssl,
 			Auth: &auth,
 		}
@@ -167,6 +170,7 @@ func TestFindOne(t *testing.T) {
 			Connection: &options.Connection{
 				Port: DefaultTestPort,
 			},
+			URI:  &options.URI{},
 			SSL:  &ssl,
 			Auth: &auth,
 		}
@@ -200,6 +204,7 @@ func TestGetIndexes(t *testing.T) {
 			Connection: &options.Connection{
 				Port: DefaultTestPort,
 			},
+			URI:  &options.URI{},
 			SSL:  &ssl,
 			Auth: &auth,
 		}
@@ -278,6 +283,7 @@ func TestServerVersionArray(t *testing.T) {
 			Connection: &options.Connection{
 				Port: DefaultTestPort,
 			},
+			URI:  &options.URI{},
 			SSL:  &ssl,
 			Auth: &auth,
 		}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -93,6 +93,29 @@ func TestNewSessionProvider(t *testing.T) {
 
 }
 
+func TestConfigureClientForSRV(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
+
+	Convey("Configuring options with a URI with invalid auth should succeed", t, func() {
+		enabled := options.EnabledOptions{
+			Auth:       true,
+			Connection: true,
+			Namespace:  true,
+			URI:        true,
+		}
+
+		toolOptions := options.New("test", "", "", "", true, enabled)
+		// AuthSource without a username is invalid, we want to check the URI does not get
+		// validated as part of client configuration
+		_, err := toolOptions.ParseArgs([]string{"--uri", "mongodb://foo/?authSource=admin", "--username", "bar"})
+		So(err, ShouldBeNil)
+
+		_, err = configureClient(*toolOptions)
+		So(err, ShouldBeNil)
+	})
+
+}
+
 func TestDatabaseNames(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.IntegrationTestType)
 

--- a/options/options.go
+++ b/options/options.go
@@ -789,7 +789,7 @@ func (opts *ToolOptions) setOptionsFromURI(cs connstring.ConnString) error {
 
 	if opts.SSLPEMKeyFile != "" && cs.SSLClientCertificateKeyFileSet {
 		if opts.SSLPEMKeyFile != cs.SSLClientCertificateKeyFile {
-			return ConflictingArgsErrorFormat("sslPEMKeyFile", cs.SSLClientCertificateKeyFile, opts.SSLPEMKeyFile, "--sslPEMKeyFile")
+			return ConflictingArgsErrorFormat("sslClientCertificateKeyFile", cs.SSLClientCertificateKeyFile, opts.SSLPEMKeyFile, "--sslPEMKeyFile")
 		}
 	}
 	if opts.SSLPEMKeyFile != "" && !cs.SSLClientCertificateKeyFileSet {
@@ -802,7 +802,7 @@ func (opts *ToolOptions) setOptionsFromURI(cs connstring.ConnString) error {
 
 	if opts.SSLPEMKeyPassword != "" && cs.SSLClientCertificateKeyPasswordSet {
 		if opts.SSLPEMKeyPassword != cs.SSLClientCertificateKeyPassword() {
-			return ConflictingArgsErrorFormat("sslPEMKeyFile", cs.SSLClientCertificateKeyPassword(), opts.SSLPEMKeyPassword, "--sslPEMKeyFile")
+			return ConflictingArgsErrorFormat("sslPEMKeyFilePassword", cs.SSLClientCertificateKeyPassword(), opts.SSLPEMKeyPassword, "--sslPEMKeyFilePassword")
 		}
 	}
 	if opts.SSLPEMKeyPassword != "" && !cs.SSLClientCertificateKeyPasswordSet {
@@ -817,7 +817,7 @@ func (opts *ToolOptions) setOptionsFromURI(cs connstring.ConnString) error {
 
 	if cs.SSLInsecureSet {
 		if (opts.SSLAllowInvalidCert || opts.SSLAllowInvalidHost) && !cs.SSLInsecure {
-			return ConflictingArgsErrorFormat("sslPEMKeyFile", "false", "true", "--sslAllowInvalidCert or --sslAllowInvalidHost")
+			return ConflictingArgsErrorFormat("sslInsecure or tlsInsecure", "false", "true", "--sslAllowInvalidCert or --sslAllowInvalidHost")
 		}
 		opts.SSLAllowInvalidCert = cs.SSLInsecure
 		opts.SSLAllowInvalidHost = cs.SSLInsecure

--- a/options/options.go
+++ b/options/options.go
@@ -377,7 +377,7 @@ func (auth *Auth) ShouldAskForPassword() bool {
 }
 
 func NewURI(unparsed string) (*URI, error) {
-	cs, err := connstring.ParseAndValidate(unparsed)
+	cs, err := connstring.Parse(unparsed)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing URI from %v: %v", unparsed, err)
 	}
@@ -687,17 +687,17 @@ func (opts *ToolOptions) setOptionsFromURI(cs connstring.ConnString) error {
 			return fmt.Errorf("must set a username when using an SRV scheme")
 		}
 
-		if opts.Password != "" && cs.Password != "" {
+		if opts.Password != "" && cs.PasswordSet {
 			if opts.Password != cs.Password {
 				return fmt.Errorf("Invalid Options: Cannot specify different password in connection URI and command-line option")
 			}
 		}
-		if opts.Password != "" && cs.PasswordSet {
+		if opts.Password != "" && !cs.PasswordSet {
 			cs.Password = opts.Password
-		}
-		if opts.Password == "" && !cs.PasswordSet {
-			opts.Password = cs.Password
 			cs.PasswordSet = true
+		}
+		if opts.Password == "" && cs.PasswordSet {
+			opts.Password = cs.Password
 		}
 
 		if opts.Source != "" && cs.AuthSourceSet {

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -613,6 +613,7 @@ func TestOptionsParsingForSRV(t *testing.T) {
 		testCases := []optionsTester{
 			{"", atlasURI, ShouldFail},
 			{"--username foo", atlasURI, ShouldSucceed},
+			{"--username foo --password bar", atlasURI, ShouldSucceed},
 			{"--username foo --authenticationDatabase admin", atlasURI, ShouldSucceed},
 			{"--username foo --authenticationDatabase db1", atlasURI, ShouldFail},
 			{"--username foo --ssl", atlasURI, ShouldSucceed},

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -419,7 +419,7 @@ func TestParseAndSetOptions(t *testing.T) {
 					BuiltWithGSSAPI = true
 				}()
 
-				testCase.OptsIn.URI.connString = testCase.CS
+				testCase.OptsIn.URI.ConnString = testCase.CS
 
 				err := testCase.OptsIn.setOptionsFromURI(testCase.CS)
 

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -264,6 +264,7 @@ func TestParseAndSetOptions(t *testing.T) {
 					AuthSourceSet: true,
 					Username:      "user",
 					Password:      "password",
+					PasswordSet:   true,
 				},
 				OptsIn: &ToolOptions{
 					General:        &General{},

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -62,6 +62,10 @@ func GetBareSessionProvider() (*db.SessionProvider, *options.ToolOptions, error)
 			URI:        &options.URI{},
 		}
 	}
+	err := toolOptions.NormalizeOptionsAndURI()
+	if err != nil {
+		return nil, nil, err
+	}
 	sessionProvider, err := db.NewSessionProvider(*toolOptions)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
The CLI options don't cover all URI options. So we want to ensure that any URI options not covered by CLI options make it through to the client configuration. This was achieved by using `ApplyURI()`. All options set in the URI would be applied to the client in this way, then all CLI options would be applied, overwriting any options already set by `ApplyURI()`. This overwriting would be safe because `NormalizeOptionsAndURI()` ensures the CLI and URI options are the same.* However, `ApplyURI()` calls `parser.validate()` on the `ConnString` object. This causes a validation error if you have invalid auth/ssl settings which could arise if you're using a URI in combination with options.

The Go Driver team are planning on adding an `ApplyConnString()` method to `ClientOptions` and moving the `parser.validate()` logic into `ClientOptions.validate()`. This would allow us to sidestep using `ApplyURI()` and apply the full, consolidated ConnString object instead. 

However, in the time being, this PR moves the ApplyURI logic that sets client options from a ConnString object into `configureClient()`.

TOOLS-2520 is wrapped into this PR too. It included necessary bugfixes. 

*One interesting quirk here is that `SetTLSConfig()` overwrites the entire TLS Config, so before `NormalizeOptionsAndURI()`, if a user used a mix of URI and CLI options to specify TLS options, the URI options would be completely ignored. 