### PR TITLE
TOOLS-2555: Support directConnection option

### DIFF
--- a/options/options_test.go
+++ b/options/options_test.go
@@ -352,6 +352,26 @@ func TestParseAndSetOptions(t *testing.T) {
 				ShouldError: false,
 			},
 			{
+				Name: "direct connection sets 'Direct'",
+				CS: connstring.ConnString{
+					DirectConnection: true,
+				},
+				OptsIn: New("", "", "", "", true, enabledURIOnly),
+				OptsExpected: &ToolOptions{
+					General:        &General{},
+					Verbosity:      &Verbosity{},
+					Connection:     &Connection{},
+					URI:            &URI{},
+					SSL:            &SSL{},
+					Auth:           &Auth{},
+					Direct:         true,
+					Namespace:      &Namespace{},
+					Kerberos:       &Kerberos{},
+					enabledOptions: EnabledOptions{URI: true},
+				},
+				ShouldError: false,
+			},
+			{
 				Name: "ReplSetName is set when CS contains it",
 				CS: connstring.ConnString{
 					ReplicaSet: "replset",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2555

This PR adds the `ConnString.directConnection` driver option to tools. The driver option was added in [this mongo-go-driver commit](https://github.com/mongodb/mongo-go-driver/commit/68130e6287ad8873c9e7ef55e9146d8d6c9feb7a).

The first commit to this PR is solely the tools-specific changes, just for clarity of reading. The second one is after running `dep ensure -update go.mongodb.org/mongo-driver` and includes the driver related changes too.