### PR TITLE
TOOLS-2498: add function to reset failpoint setting for testing

### DIFF
--- a/failpoint/failpoint.go
+++ b/failpoint/failpoint.go
@@ -19,6 +19,10 @@ func init() {
 	values = make(map[string]string)
 }
 
+func Reset() {
+	values = make(map[string]string)
+}
+
 // ParseFailpoints registers a comma-separated list of failpoint=value pairs
 func ParseFailpoints(arg string) {
 	args := strings.Split(arg, ",")


### PR DESCRIPTION
This is required in https://github.com/mongodb/mongo-tools/pull/245, since I need a way to reset the failpoint setting from test cases.