### PR TITLE
TOOLS-2597: fix the error message check in positional uri parse

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -499,7 +499,7 @@ func (opts *ToolOptions) setURIFromPositionalArg(args []string) ([]string, error
 			}
 			foundURI = true
 			parsedURI = cs
-		} else if err.Error() == "error parsing uri: scheme must be 'mongodb'' or 'mongodb+srv'" {
+		} else if err.Error() == "error parsing uri: scheme must be \"mongodb\" or \"mongodb+srv\"" {
 			newArgs = append(newArgs, arg)
 		} else {
 			return []string{}, err

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -671,6 +671,29 @@ func TestOptionsParsing(t *testing.T) {
 	})
 }
 
+func TestParsePositionalArgsAsURI(t *testing.T) {
+	enabled := EnabledOptions{
+		Auth:       true,
+		Connection: true,
+		Namespace:  true,
+		URI:        true,
+	}
+	toolOptions := New("test", "", "", "", true, enabled)
+
+	Convey("Uri as positional argument", t, func() {
+		Convey("schema error is not reported", func() {
+			args := []string{"localhost:27017"}
+			_, err := toolOptions.ParseArgs(args)
+			So(err, ShouldBeNil)
+		})
+		Convey("non-schema errors should be reported", func() {
+			args := []string{"mongodb://a/b@localhost:27017"}
+			_, err := toolOptions.ParseArgs(args)
+			So(err.Error(), ShouldEqual, "error parsing uri: unescaped slash in username")
+		})
+	})
+}
+
 func TestOptionsParsingForSRV(t *testing.T) {
 
 	testtype.SkipUnlessTestType(t, testtype.SRVConnectionStringTestType)


### PR DESCRIPTION
@tfogo I found the error message in my previous PR was not accurate https://github.com/mongodb/mongo-tools-common/pull/38. It could be due to the auto-correction inside my IDE. I am fixing it here and added test case for positional args. Thx.