### PR TITLE
TOOLS-2670: Troubleshoot IAM auth options errors

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -845,6 +845,9 @@ func (opts *ToolOptions) setOptionsFromURI(cs connstring.ConnString) error {
 			}
 		}
 		if opts.AWSSessionToken != "" && !cs.AuthMechanismPropertiesSet {
+			if cs.AuthMechanismProperties == nil {
+				cs.AuthMechanismProperties = make(map[string]string)
+			}
 			cs.AuthMechanismProperties["AWS_SESSION_TOKEN"] = opts.AWSSessionToken
 			cs.AuthMechanismPropertiesSet = true
 		}


### PR DESCRIPTION
When a user supplies an invalid AWS Session Token, `setOptionsFromURI` results in a panic. I'm not sure why the relevant test was passing before the change because `AuthMechanismProperties` isn't initialized in `mongo-go-driver/x/mongo/driver/connstring/connstring.go`, though I think it should be.