### PR TITLE
TOOLS-2645: normalize the output for ConvertLegacyIndexKeys

### DIFF
--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -1,8 +1,6 @@
 package bsonutil
 
 import (
-	"strconv"
-
 	"github.com/mongodb/mongo-tools-common/log"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -69,11 +67,6 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 			if v == "" {
 				indexKey[j].Value = 1
 				converted = true
-			} else {
-				if intVal, err := strconv.Atoi(v); err == nil {
-					indexVal = intVal
-					needsConversion = true
-				}
 			}
 		default:
 			// Convert all types that aren't strings or numbers

--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -1,6 +1,8 @@
 package bsonutil
 
 import (
+	"strconv"
+
 	"github.com/mongodb/mongo-tools-common/log"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -40,39 +42,50 @@ var validIndexOptions = map[string]bool{
 // All other strings that aren't one of ["2d", "geoHaystack", "2dsphere", "hashed", "text", ""]
 // will cause the index build to fail. See TOOLS-2412 for more information.
 //
-// Note, this function doesn't convert Decimal values which are equivalent to "0" (e.g. 0.00 or -0).
-//
 // This function logs the keys that are converted.
 func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 	var converted bool
 	originalJSONString := CreateExtJSONString(indexKey)
 	for j, elem := range indexKey {
+		indexVal := 1
+		needsConversion := false
 		switch v := elem.Value.(type) {
-		case int32, int64, float64:
-			// Only convert 0 value
-			if v == 0 {
-				indexKey[j].Value = 1
-				converted = true
-			}
+		case int32:
+			indexVal = int(v)
+			needsConversion = true
+		case int64:
+			indexVal = int(v)
+			needsConversion = true
+		case float64:
+			indexVal = int(v)
+			needsConversion = true
 		case primitive.Decimal128:
-			// Note, this doesn't catch Decimal values which are equivalent to "0" (e.g. 0.00 or -0).
-			// These values are so unlikely we just ignore them
-			zeroVal, err := primitive.ParseDecimal128("0")
-			if err == nil {
-				if v == zeroVal {
-					indexKey[j].Value = 1
-					converted = true
-				}
+			if intVal, _, err := v.BigInt(); err == nil {
+				indexVal = int(intVal.Int64())
+
+				needsConversion = true
 			}
 		case string:
-			// Only convert an empty string
 			if v == "" {
 				indexKey[j].Value = 1
 				converted = true
+			} else {
+				if intVal, err := strconv.Atoi(v); err == nil {
+					indexVal = intVal
+					needsConversion = true
+				}
 			}
 		default:
 			// Convert all types that aren't strings or numbers
 			indexKey[j].Value = 1
+			converted = true
+		}
+		if needsConversion {
+			if indexVal < 0 {
+				indexKey[j].Value = -1
+			} else {
+				indexKey[j].Value = 1
+			}
 			converted = true
 		}
 	}

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -7,7 +7,6 @@
 package bsonutil
 
 import (
-	"github.com/mongodb/mongo-tools-common/testtype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 )
 
 func TestConvertLegacyIndexKeys(t *testing.T) {
-	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+	//testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
 	Convey("Converting legacy Indexes", t, func() {
 		index1Key := bson.D{{"foo", 0}, {"int32field", int32(1)},
@@ -31,9 +30,9 @@ func TestConvertLegacyIndexKeys(t *testing.T) {
 		ConvertLegacyIndexKeys(index2Key, "test")
 		So(index2Key, ShouldResemble, bson.D{{"key1", -1},{"key2", 1}, {"key3", 1}})
 
-		index3Key := bson.D{{"key1", ""}, {"key2", "1"}, {"key3", "1"}, {"key4", "-1"}}
+		index3Key := bson.D{{"key1", ""}, {"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}}
 		ConvertLegacyIndexKeys(index3Key, "test")
-		So(index3Key, ShouldResemble, bson.D{{"key1", 1},{"key2", 1}, {"key3", 1}, {"key4", -1}})
+		So(index3Key, ShouldResemble, bson.D{{"key1", 1},{"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}})
 
 		index4Key := bson.D{{"key1", bson.E{"invalid", 1}}, {"key2", primitive.Binary{}}}
 		ConvertLegacyIndexKeys(index4Key, "test")

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -7,6 +7,7 @@
 package bsonutil
 
 import (
+	"github.com/mongodb/mongo-tools-common/testtype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"testing"
 
@@ -15,7 +16,7 @@ import (
 )
 
 func TestConvertLegacyIndexKeys(t *testing.T) {
-	//testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
 	Convey("Converting legacy Indexes", t, func() {
 		index1Key := bson.D{{"foo", 0}, {"int32field", int32(1)},

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -1,0 +1,43 @@
+// Copyright (C) MongoDB, Inc. 2014-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package bsonutil
+
+import (
+	"github.com/mongodb/mongo-tools-common/testtype"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestConvertLegacyIndexKeys(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	Convey("Converting legacy Indexes", t, func() {
+		index1Key := bson.D{{"foo", 0}, {"int32field", int32(1)},
+			{"int64field", int64(-1)}, {"float64field", float64(-1)}}
+		ConvertLegacyIndexKeys(index1Key, "test")
+		So(index1Key, ShouldResemble, bson.D{{"foo", 1}, {"int32field", 1}, {"int64field", -1}, {"float64field", -1}})
+
+		decimal1, _ := primitive.ParseDecimal128("-1")
+		decimal2, _ := primitive.ParseDecimal128("0.00")
+		decimal3, _ := primitive.ParseDecimal128("1")
+		index2Key := bson.D{{"key1", decimal1}, {"key2", decimal2}, {"key3", decimal3}}
+		ConvertLegacyIndexKeys(index2Key, "test")
+		So(index2Key, ShouldResemble, bson.D{{"key1", -1},{"key2", 1}, {"key3", 1}})
+
+		index3Key := bson.D{{"key1", ""}, {"key2", "1"}, {"key3", "1"}, {"key4", "-1"}}
+		ConvertLegacyIndexKeys(index3Key, "test")
+		So(index3Key, ShouldResemble, bson.D{{"key1", 1},{"key2", 1}, {"key3", 1}, {"key4", -1}})
+
+		index4Key := bson.D{{"key1", bson.E{"invalid", 1}}, {"key2", primitive.Binary{}}}
+		ConvertLegacyIndexKeys(index4Key, "test")
+		So(index4Key, ShouldResemble, bson.D{{"key1", 1},{"key2", 1}})
+	})
+}
+


### PR DESCRIPTION
This is a dependency for https://github.com/mongodb/mongo-tools/compare/master...huan-Mongo:TOOLS-2645. We need to normalize the index key value in order to find the duplicated index key after convert legacy indexes. 