### PR TITLE
TOOLS-2587: fix convert legacy indexes

### DIFF
--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -45,39 +45,39 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 	var converted bool
 	originalJSONString := CreateExtJSONString(indexKey)
 	for j, elem := range indexKey {
-		indexVal := 1
+		indexVal := int32(1)
 		needsConversion := false
 		switch v := elem.Value.(type) {
 		case int32:
-			indexVal = int(v)
+			indexVal = int32(v)
 			needsConversion = true
 		case int64:
-			indexVal = int(v)
+			indexVal = int32(v)
 			needsConversion = true
 		case float64:
-			indexVal = int(v)
+			indexVal = int32(v)
 			needsConversion = true
 		case primitive.Decimal128:
 			if intVal, _, err := v.BigInt(); err == nil {
-				indexVal = int(intVal.Int64())
+				indexVal = int32(intVal.Int64())
 
 				needsConversion = true
 			}
 		case string:
 			if v == "" {
-				indexKey[j].Value = 1
+				indexKey[j].Value = int32(1)
 				converted = true
 			}
 		default:
 			// Convert all types that aren't strings or numbers
-			indexKey[j].Value = 1
+			indexKey[j].Value = int32(1)
 			converted = true
 		}
 		if needsConversion {
 			if indexVal < 0 {
-				indexKey[j].Value = -1
+				indexKey[j].Value = int32(-1)
 			} else {
-				indexKey[j].Value = 1
+				indexKey[j].Value = int32(1)
 			}
 			converted = true
 		}

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -22,22 +22,22 @@ func TestConvertLegacyIndexKeys(t *testing.T) {
 		index1Key := bson.D{{"foo", 0}, {"int32field", int32(1)},
 			{"int64field", int64(-1)}, {"float64field", float64(-1)}}
 		ConvertLegacyIndexKeys(index1Key, "test")
-		So(index1Key, ShouldResemble, bson.D{{"foo", 1}, {"int32field", 1}, {"int64field", -1}, {"float64field", -1}})
+		So(index1Key, ShouldResemble, bson.D{{"foo", int32(1)}, {"int32field", int32(1)}, {"int64field", int32(-1)}, {"float64field", int32(-1)}})
 
 		decimal1, _ := primitive.ParseDecimal128("-1")
 		decimal2, _ := primitive.ParseDecimal128("0.00")
 		decimal3, _ := primitive.ParseDecimal128("1")
 		index2Key := bson.D{{"key1", decimal1}, {"key2", decimal2}, {"key3", decimal3}}
 		ConvertLegacyIndexKeys(index2Key, "test")
-		So(index2Key, ShouldResemble, bson.D{{"key1", -1},{"key2", 1}, {"key3", 1}})
+		So(index2Key, ShouldResemble, bson.D{{"key1", int32(-1)},{"key2", int32(1)}, {"key3", int32(1)}})
 
 		index3Key := bson.D{{"key1", ""}, {"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}}
 		ConvertLegacyIndexKeys(index3Key, "test")
-		So(index3Key, ShouldResemble, bson.D{{"key1", 1},{"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}})
+		So(index3Key, ShouldResemble, bson.D{{"key1", int32(1)},{"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}})
 
 		index4Key := bson.D{{"key1", bson.E{"invalid", 1}}, {"key2", primitive.Binary{}}}
 		ConvertLegacyIndexKeys(index4Key, "test")
-		So(index4Key, ShouldResemble, bson.D{{"key1", 1},{"key2", 1}})
+		So(index4Key, ShouldResemble, bson.D{{"key1", int32(1)},{"key2", int32(1)}})
 	})
 }
 


### PR DESCRIPTION
In the previous change https://github.com/mongodb/mongo-tools-common/pull/45/files#diff-50d9b99959b73a73ee60970b7f331a69R48, I followed the old logic to standardize the output of convertLegacyIndexex index value to `int` type. This change works with no problem. 

However, it brought some issue in tests in Mongomirror, since Mongo Drive decodes the indexes key value as `int32` during listIndexes and bson.UnmarshalExtJSON. 

Here I change all convert index key value to `int32` instead.