### PR TITLE
Tools-2710: fix convertLegacyIndexes

### DIFF
--- a/bsonutil/bsonutil.go
+++ b/bsonutil/bsonutil.go
@@ -458,9 +458,8 @@ func Bson2Float64(data interface{}) (float64, bool) {
 		if bi, _, err := v.BigInt(); err == nil {
 			intVal := bi.Int64()
 			return float64(intVal), true
-		} else {
-			return 0, false
 		}
+		return 0, false
 	case string:
 		if val, err := strconv.ParseFloat(v, 64); err == nil {
 			return val, true

--- a/bsonutil/bsonutil.go
+++ b/bsonutil/bsonutil.go
@@ -427,3 +427,44 @@ func parseNumberLongField(jsonValue interface{}) (int64, error) {
 		return 0, errors.New("expected $numberLong field to have string value")
 	}
 }
+
+func Bson2Float64(data interface{}) (float64, bool) {
+	switch v := data.(type) {
+	case uint:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int8:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case primitive.Decimal128:
+		if bi, _, err := v.BigInt(); err == nil {
+			intVal := bi.Int64()
+			return float64(intVal), true
+		} else {
+			return 0, false
+		}
+	case string:
+		if val, err := strconv.ParseFloat(v, 64); err == nil {
+			return val, true
+		}
+	}
+	return 0, false
+}

--- a/bsonutil/bsonutil.go
+++ b/bsonutil/bsonutil.go
@@ -430,20 +430,6 @@ func parseNumberLongField(jsonValue interface{}) (int64, error) {
 
 func Bson2Float64(data interface{}) (float64, bool) {
 	switch v := data.(type) {
-	case uint:
-		return float64(v), true
-	case uint8:
-		return float64(v), true
-	case uint16:
-		return float64(v), true
-	case uint32:
-		return float64(v), true
-	case uint64:
-		return float64(v), true
-	case int:
-		return float64(v), true
-	case int8:
-		return float64(v), true
 	case int16:
 		return float64(v), true
 	case int32:
@@ -452,18 +438,12 @@ func Bson2Float64(data interface{}) (float64, bool) {
 		return float64(v), true
 	case float64:
 		return v, true
-	case float32:
-		return float64(v), true
 	case primitive.Decimal128:
 		if bi, _, err := v.BigInt(); err == nil {
 			intVal := bi.Int64()
 			return float64(intVal), true
 		}
 		return 0, false
-	case string:
-		if val, err := strconv.ParseFloat(v, 64); err == nil {
-			return val, true
-		}
 	}
 	return 0, false
 }

--- a/bsonutil/bsonutil.go
+++ b/bsonutil/bsonutil.go
@@ -430,8 +430,6 @@ func parseNumberLongField(jsonValue interface{}) (int64, error) {
 
 func Bson2Float64(data interface{}) (float64, bool) {
 	switch v := data.(type) {
-	case int16:
-		return float64(v), true
 	case int32:
 		return float64(v), true
 	case int64:

--- a/bsonutil/bsonutil_test.go
+++ b/bsonutil/bsonutil_test.go
@@ -21,6 +21,7 @@ func TestBson2Float64(t *testing.T) {
 		{int64(1), 1.0, true},
 		{1.0, 1.0, true},
 		{decimalVal, float64(-1), true},
+		{"invalid value", 0, false},
 	}
 
 	Convey("Test numerical value conversion", t, func() {

--- a/bsonutil/bsonutil_test.go
+++ b/bsonutil/bsonutil_test.go
@@ -1,0 +1,43 @@
+package bsonutil
+
+import (
+	"github.com/mongodb/mongo-tools-common/testtype"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"testing"
+)
+
+func TestBson2Float64(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
+	decimalVal, _ := primitive.ParseDecimal128("-1")
+	tests := []struct {
+		In interface{}
+		Expected float64
+		isSuccess bool
+	} {
+		{int8(1), 1.0, true,},
+		{int16(2), 2.0, true,},
+		{int32(1), 1.0, true,},
+		{int64(1), 1.0, true,},
+		{uint8(1), 1.0, true,},
+		{uint16(1), 1.0, true,},
+		{uint32(1), 1.0, true,},
+		{uint64(1), 1.0, true,},
+		{1.0, 1.0, true,},
+		{float32(1.0), 1.0, true,},
+		{"1", 1.0, true,},
+		{"1.5", 1.5, true,},
+		{"invalid", float64(0), false,},
+		{decimalVal, float64(-1), true,},
+	}
+
+	Convey("Test numerical value conversion", t, func() {
+		for _, test := range tests {
+			result, ok := Bson2Float64(int32(1))
+			So(ok, ShouldEqual, test.isSuccess)
+			So(result, ShouldEqual, float64(1))
+		}
+	})
+}

--- a/bsonutil/bsonutil_test.go
+++ b/bsonutil/bsonutil_test.go
@@ -13,31 +13,31 @@ func TestBson2Float64(t *testing.T) {
 
 	decimalVal, _ := primitive.ParseDecimal128("-1")
 	tests := []struct {
-		In interface{}
-		Expected float64
+		In        interface{}
+		Expected  float64
 		isSuccess bool
-	} {
-		{int8(1), 1.0, true,},
-		{int16(2), 2.0, true,},
-		{int32(1), 1.0, true,},
-		{int64(1), 1.0, true,},
-		{uint8(1), 1.0, true,},
-		{uint16(1), 1.0, true,},
-		{uint32(1), 1.0, true,},
-		{uint64(1), 1.0, true,},
-		{1.0, 1.0, true,},
-		{float32(1.0), 1.0, true,},
-		{"1", 1.0, true,},
-		{"1.5", 1.5, true,},
-		{"invalid", float64(0), false,},
-		{decimalVal, float64(-1), true,},
+	}{
+		{int8(1), 1.0, true},
+		{int16(2), 2.0, true},
+		{int32(1), 1.0, true},
+		{int64(1), 1.0, true},
+		{uint8(1), 1.0, true},
+		{uint16(1), 1.0, true},
+		{uint32(1), 1.0, true},
+		{uint64(1), 1.0, true},
+		{1.0, 1.0, true},
+		{float32(1.0), 1.0, true},
+		{"1", 1.0, true},
+		{"1.5", 1.5, true},
+		{"invalid", float64(0), false},
+		{decimalVal, float64(-1), true},
 	}
 
 	Convey("Test numerical value conversion", t, func() {
 		for _, test := range tests {
-			result, ok := Bson2Float64(int32(1))
+			result, ok := Bson2Float64(test.In)
 			So(ok, ShouldEqual, test.isSuccess)
-			So(result, ShouldEqual, float64(1))
+			So(result, ShouldEqual, test.Expected)
 		}
 	})
 }

--- a/bsonutil/bsonutil_test.go
+++ b/bsonutil/bsonutil_test.go
@@ -17,19 +17,9 @@ func TestBson2Float64(t *testing.T) {
 		Expected  float64
 		isSuccess bool
 	}{
-		{int8(1), 1.0, true},
-		{int16(2), 2.0, true},
 		{int32(1), 1.0, true},
 		{int64(1), 1.0, true},
-		{uint8(1), 1.0, true},
-		{uint16(1), 1.0, true},
-		{uint32(1), 1.0, true},
-		{uint64(1), 1.0, true},
 		{1.0, 1.0, true},
-		{float32(1.0), 1.0, true},
-		{"1", 1.0, true},
-		{"1.5", 1.5, true},
-		{"invalid", float64(0), false},
 		{decimalVal, float64(-1), true},
 	}
 

--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -93,7 +93,7 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 	originalJSONString := CreateExtJSONString(indexKey)
 	for j, elem := range indexKey {
 		switch v := elem.Value.(type) {
-		case int32, int64, float64:
+		case int, int32, int64, float64:
 			// Only convert 0 value
 			if v == 0 {
 				indexKey[j].Value = int32(1)

--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -93,10 +93,24 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 	originalJSONString := CreateExtJSONString(indexKey)
 	for j, elem := range indexKey {
 		switch v := elem.Value.(type) {
-		case int, int32, int64, float64:
-			// Only convert 0 value
+		case int:
 			if v == 0 {
+				indexKey[j].Value = 1
+				converted = true
+			}
+		case int32:
+			if v == int32(0) {
 				indexKey[j].Value = int32(1)
+				converted = true
+			}
+		case int64:
+			if v == int64(0) {
+				indexKey[j].Value = int64(1)
+				converted = true
+			}
+		case float64:
+			if math.Abs(v - float64(0)) < epsilon{
+				indexKey[j].Value = float64(1)
 				converted = true
 			}
 		case primitive.Decimal128:

--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -36,7 +36,6 @@ var validIndexOptions = map[string]bool{
 
 const epsilon = 1e-9
 
-
 func IsIndexKeysEqual(indexKey1 bson.D, indexKey2 bson.D) bool {
 	if len(indexKey1) != len(indexKey2) {
 		// two indexes have different number of keys
@@ -54,8 +53,8 @@ func IsIndexKeysEqual(indexKey1 bson.D, indexKey2 bson.D) bool {
 			if key2Value, ok := indexKey2[j].Value.(string); !ok {
 				// key2Value is numerical type
 				if key2Value, ok := Bson2Float64(indexKey2[j].Value); ok {
-					if key1Value, ok:= Bson2Float64(key1Value); ok {
-						if math.Abs(key1Value - key2Value) < epsilon {
+					if key1Value, ok := Bson2Float64(key1Value); ok {
+						if math.Abs(key1Value-key2Value) < epsilon {
 							continue
 						}
 					}
@@ -68,7 +67,7 @@ func IsIndexKeysEqual(indexKey1 bson.D, indexKey2 bson.D) bool {
 		default:
 			if key1Value, ok := Bson2Float64(key1Value); ok {
 				if key2Value, ok := Bson2Float64(indexKey2[j].Value); ok {
-					if math.Abs(key1Value - key2Value) < epsilon {
+					if math.Abs(key1Value-key2Value) < epsilon {
 						continue
 					}
 				}
@@ -81,10 +80,12 @@ func IsIndexKeysEqual(indexKey1 bson.D, indexKey2 bson.D) bool {
 
 // ConvertLegacyIndexKeys transforms the values of index definitions pre 3.4 into
 // the stricter index definitions of 3.4+. Prior to 3.4, any value in an index key
-// that isn't a negative number or that isn't a string is treated as 1.
-// The one exception is an empty string is treated as 1.
+// that isn't a negative number or that isn't a string is treated as int32(1).
+// The one exception is an empty string is treated as int32(1).
 // All other strings that aren't one of ["2d", "geoHaystack", "2dsphere", "hashed", "text", ""]
 // will cause the index build to fail. See TOOLS-2412 for more information.
+//
+// Note, this function doesn't convert Decimal values which are equivalent to "0" (e.g. 0.00 or -0).
 //
 // This function logs the keys that are converted.
 func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {

--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -5,6 +5,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"math"
+	"math/big"
 )
 
 // validIndexOptions are taken from https://github.com/mongodb/mongo/blob/master/src/mongo/db/index/index_descriptor.h
@@ -77,8 +78,6 @@ func IsIndexKeysEqual(indexKey1 bson.D, indexKey2 bson.D) bool {
 // All other strings that aren't one of ["2d", "geoHaystack", "2dsphere", "hashed", "text", ""]
 // will cause the index build to fail. See TOOLS-2412 for more information.
 //
-// Note, this function doesn't convert Decimal values which are equivalent to "0" (e.g. 0.00 or -0).
-//
 // This function logs the keys that are converted.
 func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 	var converted bool
@@ -87,7 +86,7 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 		switch v := elem.Value.(type) {
 		case int:
 			if v == 0 {
-				indexKey[j].Value = 1
+				indexKey[j].Value = int32(1)
 				converted = true
 			}
 		case int32:
@@ -97,20 +96,17 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 			}
 		case int64:
 			if v == int64(0) {
-				indexKey[j].Value = int64(1)
+				indexKey[j].Value = int32(1)
 				converted = true
 			}
 		case float64:
 			if math.Abs(v - float64(0)) < epsilon{
-				indexKey[j].Value = float64(1)
+				indexKey[j].Value = int32(1)
 				converted = true
 			}
 		case primitive.Decimal128:
-			// Note, this doesn't catch Decimal values which are equivalent to "0" (e.g. 0.00 or -0).
-			// These values are so unlikely we just ignore them
-			zeroVal, err := primitive.ParseDecimal128("0")
-			if err == nil {
-				if v == zeroVal {
+			if bi, _, err := v.BigInt(); err == nil {
+				if bi.Cmp(big.NewInt(0)) == 0 {
 					indexKey[j].Value = int32(1)
 					converted = true
 				}

--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -50,18 +50,10 @@ func IsIndexKeysEqual(indexKey1 bson.D, indexKey2 bson.D) bool {
 		// After ConvertLegacyIndexKeys, index key value should only be numerical or string value
 		switch key1Value := elem.Value.(type) {
 		case string:
-			if key2Value, ok := indexKey2[j].Value.(string); !ok {
-				// key2Value is numerical type
-				if key2Value, ok := Bson2Float64(indexKey2[j].Value); ok {
-					if key1Value, ok := Bson2Float64(key1Value); ok {
-						if math.Abs(key1Value-key2Value) < epsilon {
-							continue
-						}
-					}
+			if key2Value, ok := indexKey2[j].Value.(string); ok {
+				if key1Value == key2Value {
+					continue
 				}
-			} else if key1Value == key2Value {
-				// Both are string
-				continue
 			}
 			return false
 		default:

--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -45,39 +45,39 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 	var converted bool
 	originalJSONString := CreateExtJSONString(indexKey)
 	for j, elem := range indexKey {
-		indexVal := 1
+		indexVal := int32(1)
 		needsConversion := false
 		switch v := elem.Value.(type) {
 		case int32:
-			indexVal = int(v)
+			indexVal = int32(v)
 			needsConversion = true
 		case int64:
-			indexVal = int(v)
+			indexVal = int32(v)
 			needsConversion = true
 		case float64:
-			indexVal = int(v)
+			indexVal = int32(v)
 			needsConversion = true
 		case primitive.Decimal128:
 			if intVal, _, err := v.BigInt(); err == nil {
-				indexVal = int(intVal.Int64())
+				indexVal = int32(intVal.Int64())
 
 				needsConversion = true
 			}
 		case string:
 			if v == "" {
-				indexKey[j].Value = 1
+				indexKey[j].Value = int32(1)
 				converted = true
 			}
 		default:
 			// Convert all types that aren't strings or numbers
-			indexKey[j].Value = 1
+			indexKey[j].Value = int32(1)
 			converted = true
 		}
 		if needsConversion {
 			if indexVal < 0 {
-				indexKey[j].Value = -1
+				indexKey[j].Value = int32(-1)
 			} else {
-				indexKey[j].Value = 1
+				indexKey[j].Value = int32(1)
 			}
 			converted = true
 		}

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -24,31 +24,31 @@ func TestIsIndexKeysEqual(t *testing.T) {
 	}{
 		{bson.D{{"a", 1}, {"b", int32(1)}},
 			bson.D{{"a", float64(1)}, {"b", int64(1)}},
-			true,},
+			true},
 		{bson.D{{"a", "1"}, {"b", "1"}},
-		bson.D{{"a", 1}, {"b", int32(1)}},
-		true,},
+			bson.D{{"a", 1}, {"b", int32(1)}},
+			true},
 		{bson.D{{"a", -1.0}, {"b", "1.0"}},
 			bson.D{{"a", -1}, {"b", int32(1)}},
-			true,},
+			true},
 		{bson.D{{"a", -2.0}},
 			bson.D{{"a", -1}},
-			false,},
+			false},
 		{bson.D{{"a", "1.1"}},
 			bson.D{{"a", 1}},
-			false,},
+			false},
 		{bson.D{{"b", int32(1)}},
 			bson.D{{"a", int32(1)}},
-			false,},
+			false},
 		{bson.D{{"a", int32(1)}, {"b", int32(1)}},
 			bson.D{{"b", int32(1)}, {"a", int32(1)}},
-			false,},
+			false},
 	}
 
 	for _, test := range tests {
-		 if result := IsIndexKeysEqual(test.IndexKeys1, test.IndexKeys2); result != test.Expected {
-		 	t.Fatalf("Wrong output from IsIndexKeysEqual as expected, test: %v, actual: %v", test, result)
-		 }
+		if result := IsIndexKeysEqual(test.IndexKeys1, test.IndexKeys2); result != test.Expected {
+			t.Fatalf("Wrong output from IsIndexKeysEqual as expected, test: %v, actual: %v", test, result)
+		}
 	}
 }
 
@@ -66,17 +66,16 @@ func TestConvertLegacyIndexKeys(t *testing.T) {
 		decimalZero, _ := primitive.ParseDecimal128("0")
 		decimalOne, _ := primitive.ParseDecimal128("1")
 		decimalZero1, _ := primitive.ParseDecimal128("0.00")
-		index2Key := bson.D{{"key1", decimalNOne}, {"key2", decimalZero}, {"key3", decimalOne},  {"key4", decimalZero1}}
+		index2Key := bson.D{{"key1", decimalNOne}, {"key2", decimalZero}, {"key3", decimalOne}, {"key4", decimalZero1}}
 		ConvertLegacyIndexKeys(index2Key, "test")
-		So(index2Key, ShouldResemble, bson.D{{"key1", decimalNOne},{"key2", int32(1)}, {"key3", decimalOne},  {"key4", decimalZero1}})
+		So(index2Key, ShouldResemble, bson.D{{"key1", decimalNOne}, {"key2", int32(1)}, {"key3", decimalOne}, {"key4", decimalZero1}})
 
 		index3Key := bson.D{{"key1", ""}, {"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}}
 		ConvertLegacyIndexKeys(index3Key, "test")
-		So(index3Key, ShouldResemble, bson.D{{"key1", int32(1)},{"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}})
+		So(index3Key, ShouldResemble, bson.D{{"key1", int32(1)}, {"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}})
 
 		index4Key := bson.D{{"key1", bson.E{"invalid", 1}}, {"key2", primitive.Binary{}}}
 		ConvertLegacyIndexKeys(index4Key, "test")
-		So(index4Key, ShouldResemble, bson.D{{"key1", int32(1)},{"key2", int32(1)}})
+		So(index4Key, ShouldResemble, bson.D{{"key1", int32(1)}, {"key2", int32(1)}})
 	})
 }
-

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -66,7 +66,7 @@ func TestConvertLegacyIndexKeys(t *testing.T) {
 		decimalZero1, _ := primitive.ParseDecimal128("0.00")
 		index2Key := bson.D{{"key1", decimalNOne}, {"key2", decimalZero}, {"key3", decimalOne}, {"key4", decimalZero1}}
 		ConvertLegacyIndexKeys(index2Key, "test")
-		So(index2Key, ShouldResemble, bson.D{{"key1", decimalNOne}, {"key2", int32(1)}, {"key3", decimalOne}, {"key4", decimalZero1}})
+		So(index2Key, ShouldResemble, bson.D{{"key1", decimalNOne}, {"key2", int32(1)}, {"key3", decimalOne}, {"key4", int32(1)}})
 
 		index3Key := bson.D{{"key1", ""}, {"key2", "2dsphere"}}
 		ConvertLegacyIndexKeys(index3Key, "test")

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -17,25 +17,23 @@ import (
 
 func TestIsIndexKeysEqual(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+
 	tests := []struct {
 		IndexKeys1 bson.D
 		IndexKeys2 bson.D
 		Expected   bool
 	}{
-		{bson.D{{"a", 1}, {"b", int32(1)}},
+		{bson.D{{"a", int32(1)}, {"b", int32(1)}},
+			bson.D{{"a", int32(1)}, {"b", int64(1)}},
+			true},
+		{bson.D{{"a", int32(1)}, {"b", int32(1)}},
 			bson.D{{"a", float64(1)}, {"b", int64(1)}},
 			true},
-		{bson.D{{"a", "1"}, {"b", "1"}},
-			bson.D{{"a", 1}, {"b", int32(1)}},
-			true},
-		{bson.D{{"a", -1.0}, {"b", "1.0"}},
-			bson.D{{"a", -1}, {"b", int32(1)}},
+		{bson.D{{"a", -1.0}, {"b", 1.0}},
+			bson.D{{"a", int32(-1)}, {"b", int32(1)}},
 			true},
 		{bson.D{{"a", -2.0}},
-			bson.D{{"a", -1}},
-			false},
-		{bson.D{{"a", "1.1"}},
-			bson.D{{"a", 1}},
+			bson.D{{"a", int32(-1)}},
 			false},
 		{bson.D{{"b", int32(1)}},
 			bson.D{{"a", int32(1)}},
@@ -56,10 +54,10 @@ func TestConvertLegacyIndexKeys(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
 	Convey("Converting legacy Indexes", t, func() {
-		index1Key := bson.D{{"foo", 0}, {"int32field", int32(2)},
+		index1Key := bson.D{{"foo", int32(0)}, {"int32field", int32(2)},
 			{"int64field", int64(-3)}, {"float64field", float64(-1)}, {"float64field", float64(-1.1)}}
 		ConvertLegacyIndexKeys(index1Key, "test")
-		So(index1Key, ShouldResemble, bson.D{{"foo", 1}, {"int32field", int32(2)}, {"int64field", int64(-3)},
+		So(index1Key, ShouldResemble, bson.D{{"foo", int32(1)}, {"int32field", int32(2)}, {"int64field", int64(-3)},
 			{"float64field", float64(-1)}, {"float64field", float64(-1.1)}})
 
 		decimalNOne, _ := primitive.ParseDecimal128("-1")
@@ -70,9 +68,9 @@ func TestConvertLegacyIndexKeys(t *testing.T) {
 		ConvertLegacyIndexKeys(index2Key, "test")
 		So(index2Key, ShouldResemble, bson.D{{"key1", decimalNOne}, {"key2", int32(1)}, {"key3", decimalOne}, {"key4", decimalZero1}})
 
-		index3Key := bson.D{{"key1", ""}, {"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}}
+		index3Key := bson.D{{"key1", ""}, {"key2", "2dsphere"}}
 		ConvertLegacyIndexKeys(index3Key, "test")
-		So(index3Key, ShouldResemble, bson.D{{"key1", int32(1)}, {"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}})
+		So(index3Key, ShouldResemble, bson.D{{"key1", int32(1)}, {"key2", "2dsphere"}})
 
 		index4Key := bson.D{{"key1", bson.E{"invalid", 1}}, {"key2", primitive.Binary{}}}
 		ConvertLegacyIndexKeys(index4Key, "test")

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -7,6 +7,7 @@
 package bsonutil
 
 import (
+	"github.com/mongodb/mongo-tools-common/testtype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"testing"
 
@@ -15,13 +16,14 @@ import (
 )
 
 func TestConvertLegacyIndexKeys(t *testing.T) {
-	//testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
 	Convey("Converting legacy Indexes", t, func() {
 		index1Key := bson.D{{"foo", 0}, {"int32field", int32(2)},
-			{"int64field", int64(-3)}, {"float64field", float64(-1)}}
+			{"int64field", int64(-3)}, {"float64field", float64(-1)}, {"float64field", float64(-1.1)}}
 		ConvertLegacyIndexKeys(index1Key, "test")
-		So(index1Key, ShouldResemble, bson.D{{"foo", 1}, {"int32field", int32(2)}, {"int64field", int64(-3)}, {"float64field", float64(-1)}})
+		So(index1Key, ShouldResemble, bson.D{{"foo", 1}, {"int32field", int32(2)}, {"int64field", int64(-3)},
+			{"float64field", int32(-1)}, {"float64field", float64(-1.1)}})
 
 		decimalNOne, _ := primitive.ParseDecimal128("-1")
 		decimalZero, _ := primitive.ParseDecimal128("0.00")

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -59,7 +59,7 @@ func TestConvertLegacyIndexKeys(t *testing.T) {
 		index1Key := bson.D{{"foo", 0}, {"int32field", int32(2)},
 			{"int64field", int64(-3)}, {"float64field", float64(-1)}, {"float64field", float64(-1.1)}}
 		ConvertLegacyIndexKeys(index1Key, "test")
-		So(index1Key, ShouldResemble, bson.D{{"foo", int32(1)}, {"int32field", int32(2)}, {"int64field", int64(-3)},
+		So(index1Key, ShouldResemble, bson.D{{"foo", 1}, {"int32field", int32(2)}, {"int64field", int64(-3)},
 			{"float64field", float64(-1)}, {"float64field", float64(-1.1)}})
 
 		decimalNOne, _ := primitive.ParseDecimal128("-1")

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -41,6 +41,9 @@ func TestIsIndexKeysEqual(t *testing.T) {
 		{bson.D{{"a", int32(1)}, {"b", int32(1)}},
 			bson.D{{"b", int32(1)}, {"a", int32(1)}},
 			false},
+		{bson.D{{"a", int32(1)}, {"b", int32(1)}},
+			bson.D{{"a", int32(1)}},
+			false},
 	}
 
 	for _, test := range tests {

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -15,6 +15,43 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+func TestIsIndexKeysEqual(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+	tests := []struct {
+		IndexKeys1 bson.D
+		IndexKeys2 bson.D
+		Expected   bool
+	}{
+		{bson.D{{"a", 1}, {"b", int32(1)}},
+			bson.D{{"a", float64(1)}, {"b", int64(1)}},
+			true,},
+		{bson.D{{"a", "1"}, {"b", "1"}},
+		bson.D{{"a", 1}, {"b", int32(1)}},
+		true,},
+		{bson.D{{"a", -1.0}, {"b", "1.0"}},
+			bson.D{{"a", -1}, {"b", int32(1)}},
+			true,},
+		{bson.D{{"a", -2.0}},
+			bson.D{{"a", -1}},
+			false,},
+		{bson.D{{"a", "1.1"}},
+			bson.D{{"a", 1}},
+			false,},
+		{bson.D{{"b", int32(1)}},
+			bson.D{{"a", int32(1)}},
+			false,},
+		{bson.D{{"a", int32(1)}, {"b", int32(1)}},
+			bson.D{{"b", int32(1)}, {"a", int32(1)}},
+			false,},
+	}
+
+	for _, test := range tests {
+		 if result := IsIndexKeysEqual(test.IndexKeys1, test.IndexKeys2); result != test.Expected {
+		 	t.Fatalf("Wrong output from IsIndexKeysEqual as expected, test: %v, actual: %v", test, result)
+		 }
+	}
+}
+
 func TestConvertLegacyIndexKeys(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -7,7 +7,6 @@
 package bsonutil
 
 import (
-	"github.com/mongodb/mongo-tools-common/testtype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"testing"
 
@@ -16,20 +15,20 @@ import (
 )
 
 func TestConvertLegacyIndexKeys(t *testing.T) {
-	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+	//testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 
 	Convey("Converting legacy Indexes", t, func() {
-		index1Key := bson.D{{"foo", 0}, {"int32field", int32(1)},
-			{"int64field", int64(-1)}, {"float64field", float64(-1)}}
+		index1Key := bson.D{{"foo", 0}, {"int32field", int32(2)},
+			{"int64field", int64(-3)}, {"float64field", float64(-1)}}
 		ConvertLegacyIndexKeys(index1Key, "test")
-		So(index1Key, ShouldResemble, bson.D{{"foo", int32(1)}, {"int32field", int32(1)}, {"int64field", int32(-1)}, {"float64field", int32(-1)}})
+		So(index1Key, ShouldResemble, bson.D{{"foo", 1}, {"int32field", int32(2)}, {"int64field", int64(-3)}, {"float64field", float64(-1)}})
 
-		decimal1, _ := primitive.ParseDecimal128("-1")
-		decimal2, _ := primitive.ParseDecimal128("0.00")
-		decimal3, _ := primitive.ParseDecimal128("1")
-		index2Key := bson.D{{"key1", decimal1}, {"key2", decimal2}, {"key3", decimal3}}
+		decimalNOne, _ := primitive.ParseDecimal128("-1")
+		decimalZero, _ := primitive.ParseDecimal128("0.00")
+		decimalOne, _ := primitive.ParseDecimal128("1")
+		index2Key := bson.D{{"key1", decimalNOne}, {"key2", decimalZero}, {"key3", decimalOne}}
 		ConvertLegacyIndexKeys(index2Key, "test")
-		So(index2Key, ShouldResemble, bson.D{{"key1", int32(-1)},{"key2", int32(1)}, {"key3", int32(1)}})
+		So(index2Key, ShouldResemble, bson.D{{"key1", decimalNOne},{"key2", decimalOne}, {"key3", decimalOne}})
 
 		index3Key := bson.D{{"key1", ""}, {"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}}
 		ConvertLegacyIndexKeys(index3Key, "test")

--- a/bsonutil/indexes_test.go
+++ b/bsonutil/indexes_test.go
@@ -22,22 +22,22 @@ func TestConvertLegacyIndexKeys(t *testing.T) {
 		index1Key := bson.D{{"foo", 0}, {"int32field", int32(1)},
 			{"int64field", int64(-1)}, {"float64field", float64(-1)}}
 		ConvertLegacyIndexKeys(index1Key, "test")
-		So(index1Key, ShouldResemble, bson.D{{"foo", 1}, {"int32field", 1}, {"int64field", -1}, {"float64field", -1}})
+		So(index1Key, ShouldResemble, bson.D{{"foo", int32(1)}, {"int32field", int32(1)}, {"int64field", int32(-1)}, {"float64field", int32(-1)}})
 
 		decimal1, _ := primitive.ParseDecimal128("-1")
 		decimal2, _ := primitive.ParseDecimal128("0.00")
 		decimal3, _ := primitive.ParseDecimal128("1")
 		index2Key := bson.D{{"key1", decimal1}, {"key2", decimal2}, {"key3", decimal3}}
 		ConvertLegacyIndexKeys(index2Key, "test")
-		So(index2Key, ShouldResemble, bson.D{{"key1", -1},{"key2", 1}, {"key3", 1}})
+		So(index2Key, ShouldResemble, bson.D{{"key1", int32(-1)},{"key2", int32(1)}, {"key3", int32(1)}})
 
 		index3Key := bson.D{{"key1", ""}, {"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}}
 		ConvertLegacyIndexKeys(index3Key, "test")
-		So(index3Key, ShouldResemble, bson.D{{"key1", 1},{"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}})
+		So(index3Key, ShouldResemble, bson.D{{"key1", int32(1)},{"key2", "1"}, {"key3", "-1"}, {"key4", "2dsphere"}})
 
 		index4Key := bson.D{{"key1", bson.E{"invalid", 1}}, {"key2", primitive.Binary{}}}
 		ConvertLegacyIndexKeys(index4Key, "test")
-		So(index4Key, ShouldResemble, bson.D{{"key1", 1},{"key2", 1}})
+		So(index4Key, ShouldResemble, bson.D{{"key1", int32(1)},{"key2", int32(1)}})
 	})
 }
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -351,9 +351,9 @@ func TestAuthConnection(t *testing.T) {
 	}
 	Convey("With an AWS or Keberos auth URI", t, func() {
 		enabled := options.EnabledOptions{URI: true}
-		var uri string;
+		var uri string
 		if testtype.HasTestType(testtype.AWSAuthTestType) {
-			uri = os.Getenv("MONGOD");
+			uri = os.Getenv("MONGOD")
 		} else {
 			uri = "mongodb://" + kerberosUsername + "@" + kerberosConnection + "/kerberos?authSource=$external&authMechanism=GSSAPI"
 		}

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -563,7 +563,7 @@ func createOptionsTestCases(s []string) []optionsTester {
 		{fmt.Sprintf("%s %s", s[0], s[2]), fmt.Sprintf("mongodb://user:pass@foo/?%s=%s", s[1], s[3]), ShouldFail},
 		{"", fmt.Sprintf("mongodb://user:pass@foo/?%s=%s", s[1], s[2]), ShouldSucceed},
 	}
-	if s[0] == "--ssl" || s[0] == "--sslAllowInvalidCertificates" || s[0] == "--sslAllowInvalidHostnames" ||  s[0] == "--tlsInsecure" {
+	if s[0] == "--ssl" || s[0] == "--sslAllowInvalidCertificates" || s[0] == "--sslAllowInvalidHostnames" || s[0] == "--tlsInsecure" {
 		ret[0].options = s[0]
 		ret[1].options = s[0]
 		ret[2].options = s[0]
@@ -835,4 +835,3 @@ func TestDeprecationWarning(t *testing.T) {
 		})
 	})
 }
-


### PR DESCRIPTION
As discussed, I am changing the `ConvertLegacyIndexKeys` function to preserve the original type of value of the index key.  Zero value , the empty string, and invalid values will be converted to int32(1).