### PR TITLE
TOOLS-2688: mongodump requires EOF when passing in the password as STDIN

### DIFF
--- a/password/pass_util.go
+++ b/password/pass_util.go
@@ -24,7 +24,7 @@ func IsTerminal() bool {
 	return terminal.IsTerminal(int(syscall.Stdin))
 }
 
-func GetPass() (string, error) {
+func readPassInteractively(reader io.Reader) (string, error) {
 	oldState, err := terminal.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", err
@@ -34,7 +34,7 @@ func GetPass() (string, error) {
 	screen := struct {
 		io.Reader
 		io.Writer
-	}{os.Stdin, os.Stderr}
+	}{reader, os.Stderr}
 
 	t := terminal.NewTerminal(screen, "")
 	pass, err := t.ReadPassword("")

--- a/password/pass_util.go
+++ b/password/pass_util.go
@@ -21,10 +21,10 @@ import (
 // operating systems that aren't solaris
 
 func IsTerminal() bool {
-	return terminal.IsTerminal(int(syscall.Stdin))
+	return terminal.IsTerminal(syscall.Stdin)
 }
 
-func readPassInteractively(reader io.Reader) (string, error) {
+func readPassInteractively() (string, error) {
 	oldState, err := terminal.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", err
@@ -34,12 +34,12 @@ func readPassInteractively(reader io.Reader) (string, error) {
 	screen := struct {
 		io.Reader
 		io.Writer
-	}{reader, os.Stderr}
+	}{os.Stdin, os.Stderr}
 
 	t := terminal.NewTerminal(screen, "")
 	pass, err := t.ReadPassword("")
 	if err != nil {
 		return "", err
 	}
-	return string(pass), nil
+	return pass, nil
 }

--- a/password/pass_util.go
+++ b/password/pass_util.go
@@ -41,5 +41,5 @@ func readPassInteractively() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return pass, nil
+	return string(pass), nil
 }

--- a/password/pass_util.go
+++ b/password/pass_util.go
@@ -21,7 +21,7 @@ import (
 // operating systems that aren't solaris
 
 func IsTerminal() bool {
-	return terminal.IsTerminal(syscall.Stdin)
+	return terminal.IsTerminal(int(syscall.Stdin))
 }
 
 func readPassInteractively() (string, error) {

--- a/password/password.go
+++ b/password/password.go
@@ -10,6 +10,7 @@ package password
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/mongodb/mongo-tools-common/log"
@@ -50,6 +51,16 @@ func Prompt() (string, error) {
 // we aren't using a terminal for standard input
 func readPassFromStdin() (string, error) {
 	pass := []byte{}
+	var err error
+	fi, _ := os.Stdin.Stat()
+
+	if (fi.Mode() & os.ModeCharDevice) == 0 {
+		log.Logv(log.DebugLow, "reading data from stdin pipe")
+		pass, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return "", err
+		}
+	}
 	for {
 		var chBuf [1]byte
 		n, err := os.Stdin.Read(chBuf[:])

--- a/password/password.go
+++ b/password/password.go
@@ -64,7 +64,7 @@ func readPassFromStdin() (string, error) {
 	for {
 		var chBuf [1]byte
 		n, err := os.Stdin.Read(chBuf[:])
-		if err != nil {
+		if err != nil && err.Error() != "EOF" {
 			return "", err
 		}
 		if n == 0 {

--- a/password/password_test.go
+++ b/password/password_test.go
@@ -1,0 +1,25 @@
+package password
+
+import (
+	"bytes"
+	"github.com/mongodb/mongo-tools-common/testtype"
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+const (
+	testPwd = "test_pwd"
+)
+func TestPasswordFromNonTerminal(t *testing.T) {
+	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
+	Convey("stdin is not a terminal", t, func() {
+		var b bytes.Buffer
+
+		b.WriteString(testPwd)
+		reader := bytes.NewReader(b.Bytes())
+
+		pass, err := readPassNonInteractively(reader)
+		So(err, ShouldBeNil)
+		So(pass, ShouldEqual, testPwd)
+	})
+}

--- a/password/password_test.go
+++ b/password/password_test.go
@@ -10,6 +10,7 @@ import (
 const (
 	testPwd = "test_pwd"
 )
+
 func TestPasswordFromNonTerminal(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 	Convey("stdin is not a terminal", t, func() {

--- a/password/password_test.go
+++ b/password/password_test.go
@@ -14,10 +14,10 @@ const (
 func TestPasswordFromNonTerminal(t *testing.T) {
 	testtype.SkipUnlessTestType(t, testtype.UnitTestType)
 	Convey("stdin is not a terminal", t, func() {
-		var b bytes.Buffer
+		var buffer bytes.Buffer
 
-		b.WriteString(testPwd)
-		reader := bytes.NewReader(b.Bytes())
+		buffer.WriteString(testPwd)
+		reader := bytes.NewReader(buffer.Bytes())
 
 		pass, err := readPassNonInteractively(reader)
 		So(err, ShouldBeNil)


### PR DESCRIPTION
I've added a call to `ioutil.ReadAll()` in `readPassFromStdin()` so that we can check if a password is being piped into a mongo tool command. The subsequent `os.Stdin.Read()` call will have an error string of `EOF` if this is the case.