### PR TITLE
TOOLS-2740: Change log level names in m-t-c

### DIFF
--- a/archive/demultiplexer.go
+++ b/archive/demultiplexer.go
@@ -72,10 +72,10 @@ func (demux *Demultiplexer) Run() error {
 	parser := Parser{In: demux.In}
 	err := parser.ReadAllBlocks(demux)
 	if len(demux.outs) > 0 {
-		log.Logvf(log.Always, "demux finishing when there are still outs (%v)", len(demux.outs))
+		log.Logvf(log.Info, "demux finishing when there are still outs (%v)", len(demux.outs))
 	}
 
-	log.Logvf(log.DebugLow, "demux finishing (err:%v)", err)
+	log.Logvf(log.Trace, "demux finishing (err:%v)", err)
 	return err
 }
 
@@ -116,7 +116,7 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 	if err != nil {
 		return newWrappedError("header bson doesn't unmarshal as a collection header", err)
 	}
-	log.Logvf(log.DebugHigh, "demux namespaceHeader: %v", colHeader)
+	log.Logvf(log.Trace, "demux namespaceHeader: %v", colHeader)
 	if colHeader.Collection == "" {
 		return newError("collection header is missing a Collection")
 	}
@@ -158,11 +158,11 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 					colHeader.CRC,
 				)
 			}
-			log.Logvf(log.DebugHigh,
+			log.Logvf(log.Trace,
 				"demux checksum for namespace %v is correct (%v), %v bytes",
 				demux.currentNamespace, crc, length)
 		} else {
-			log.Logvf(log.DebugHigh,
+			log.Logvf(log.Trace,
 				"demux checksum for namespace %v was not calculated.",
 				demux.currentNamespace)
 		}
@@ -177,7 +177,7 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 
 // End is part of the ParserConsumer interface and receives the end of archive notification.
 func (demux *Demultiplexer) End() error {
-	log.Logvf(log.DebugHigh, "demux End")
+	log.Logvf(log.Trace, "demux End")
 	var err error
 	if len(demux.outs) != 0 {
 		openNss := []string{}
@@ -227,7 +227,7 @@ func (demux *Demultiplexer) Open(ns string, out DemuxOut) {
 	// or while the demutiplexer is inside of the NamespaceChan NamespaceErrorChan conversation
 	// I think that we don't need to lock outs, but I suspect that if the implementation changes
 	// we may need to lock when outs is accessed
-	log.Logvf(log.DebugHigh, "demux Open")
+	log.Logvf(log.Trace, "demux Open")
 	if demux.outs == nil {
 		demux.outs = make(map[string]DemuxOut)
 		demux.lengths = make(map[string]int64)

--- a/archive/demultiplexer.go
+++ b/archive/demultiplexer.go
@@ -72,10 +72,10 @@ func (demux *Demultiplexer) Run() error {
 	parser := Parser{In: demux.In}
 	err := parser.ReadAllBlocks(demux)
 	if len(demux.outs) > 0 {
-		log.Logvf(log.Info, "demux finishing when there are still outs (%v)", len(demux.outs))
+		log.Logvf(log.Info, false, "demux finishing when there are still outs (%v)", len(demux.outs))
 	}
 
-	log.Logvf(log.Trace, "demux finishing (err:%v)", err)
+	log.Logvf(log.Trace, false, "demux finishing (err:%v)", err)
 	return err
 }
 
@@ -116,7 +116,7 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 	if err != nil {
 		return newWrappedError("header bson doesn't unmarshal as a collection header", err)
 	}
-	log.Logvf(log.Trace, "demux namespaceHeader: %v", colHeader)
+	log.Logvf(log.Trace, false, "demux namespaceHeader: %v", colHeader)
 	if colHeader.Collection == "" {
 		return newError("collection header is missing a Collection")
 	}
@@ -159,11 +159,11 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 				)
 			}
 			log.Logvf(log.Trace,
-				"demux checksum for namespace %v is correct (%v), %v bytes",
+				false, "demux checksum for namespace %v is correct (%v), %v bytes",
 				demux.currentNamespace, crc, length)
 		} else {
 			log.Logvf(log.Trace,
-				"demux checksum for namespace %v was not calculated.",
+				false, "demux checksum for namespace %v was not calculated.",
 				demux.currentNamespace)
 		}
 		delete(demux.outs, demux.currentNamespace)
@@ -177,7 +177,7 @@ func (demux *Demultiplexer) HeaderBSON(buf []byte) error {
 
 // End is part of the ParserConsumer interface and receives the end of archive notification.
 func (demux *Demultiplexer) End() error {
-	log.Logvf(log.Trace, "demux End")
+	log.Logvf(log.Trace, false, "demux End")
 	var err error
 	if len(demux.outs) != 0 {
 		openNss := []string{}
@@ -227,7 +227,7 @@ func (demux *Demultiplexer) Open(ns string, out DemuxOut) {
 	// or while the demutiplexer is inside of the NamespaceChan NamespaceErrorChan conversation
 	// I think that we don't need to lock outs, but I suspect that if the implementation changes
 	// we may need to lock when outs is accessed
-	log.Logvf(log.Trace, "demux Open")
+	log.Logvf(log.Trace, false, "demux Open")
 	if demux.outs == nil {
 		demux.outs = make(map[string]DemuxOut)
 		demux.lengths = make(map[string]int64)

--- a/archive/multiplexer.go
+++ b/archive/multiplexer.go
@@ -74,7 +74,7 @@ func (mux *Multiplexer) Run() {
 		EOF := !notEOF
 		if index == 0 { //Control index
 			if EOF {
-				log.Logvf(log.Trace, "Mux finish")
+				log.Logvf(log.Trace, false, "Mux finish")
 				mux.Out.Close()
 				if completionErr != nil {
 					mux.Completed <- completionErr
@@ -91,7 +91,7 @@ func (mux *Multiplexer) Run() {
 				mux.Completed <- fmt.Errorf("non MuxIn received on Control chan") // one for the MuxIn.Open
 				return
 			}
-			log.Logvf(log.Trace, "Mux open namespace %v", muxIn.Intent.Namespace())
+			log.Logvf(log.Trace, false, "Mux open namespace %v", muxIn.Intent.Namespace())
 			mux.selectCases = append(mux.selectCases, reflect.SelectCase{
 				Dir:  reflect.SelectRecv,
 				Chan: reflect.ValueOf(muxIn.writeChan),
@@ -114,7 +114,7 @@ func (mux *Multiplexer) Run() {
 					mux.Out = &nopCloseNopWriter{}
 					completionErr = err
 				}
-				log.Logvf(log.Trace, "Mux close namespace %v", mux.ins[index].Intent.Namespace())
+				log.Logvf(log.Trace, false, "Mux close namespace %v", mux.ins[index].Intent.Namespace())
 				mux.currentNamespace = ""
 				mux.selectCases = append(mux.selectCases[:index], mux.selectCases[index+1:]...)
 				mux.ins = append(mux.ins[:index], mux.ins[index+1:]...)
@@ -249,7 +249,7 @@ func (muxIn *MuxIn) Pos() int64 {
 // formatEOF to occur.
 func (muxIn *MuxIn) Close() error {
 	// the mux side of this gets closed in the mux when it gets an eof on the read
-	log.Logvf(log.Trace, "MuxIn close %v", muxIn.Intent.Namespace())
+	log.Logvf(log.Trace, false, "MuxIn close %v", muxIn.Intent.Namespace())
 	if bufferWrites {
 		muxIn.writeChan <- muxIn.buf
 		length := <-muxIn.writeLenChan
@@ -270,7 +270,7 @@ func (muxIn *MuxIn) Close() error {
 // Open is implemented in Mux.open, but in short, it creates chans and a select case
 // and adds the SelectCase and the MuxIn in to the Multiplexer.
 func (muxIn *MuxIn) Open() error {
-	log.Logvf(log.Trace, "MuxIn open %v", muxIn.Intent.Namespace())
+	log.Logvf(log.Trace, false, "MuxIn open %v", muxIn.Intent.Namespace())
 	muxIn.writeChan = make(chan []byte)
 	muxIn.writeLenChan = make(chan int)
 	muxIn.writeCloseFinishedChan = make(chan struct{})

--- a/archive/multiplexer.go
+++ b/archive/multiplexer.go
@@ -74,7 +74,7 @@ func (mux *Multiplexer) Run() {
 		EOF := !notEOF
 		if index == 0 { //Control index
 			if EOF {
-				log.Logvf(log.DebugLow, "Mux finish")
+				log.Logvf(log.Trace, "Mux finish")
 				mux.Out.Close()
 				if completionErr != nil {
 					mux.Completed <- completionErr
@@ -91,7 +91,7 @@ func (mux *Multiplexer) Run() {
 				mux.Completed <- fmt.Errorf("non MuxIn received on Control chan") // one for the MuxIn.Open
 				return
 			}
-			log.Logvf(log.DebugLow, "Mux open namespace %v", muxIn.Intent.Namespace())
+			log.Logvf(log.Trace, "Mux open namespace %v", muxIn.Intent.Namespace())
 			mux.selectCases = append(mux.selectCases, reflect.SelectCase{
 				Dir:  reflect.SelectRecv,
 				Chan: reflect.ValueOf(muxIn.writeChan),
@@ -114,7 +114,7 @@ func (mux *Multiplexer) Run() {
 					mux.Out = &nopCloseNopWriter{}
 					completionErr = err
 				}
-				log.Logvf(log.DebugLow, "Mux close namespace %v", mux.ins[index].Intent.Namespace())
+				log.Logvf(log.Trace, "Mux close namespace %v", mux.ins[index].Intent.Namespace())
 				mux.currentNamespace = ""
 				mux.selectCases = append(mux.selectCases[:index], mux.selectCases[index+1:]...)
 				mux.ins = append(mux.ins[:index], mux.ins[index+1:]...)
@@ -249,7 +249,7 @@ func (muxIn *MuxIn) Pos() int64 {
 // formatEOF to occur.
 func (muxIn *MuxIn) Close() error {
 	// the mux side of this gets closed in the mux when it gets an eof on the read
-	log.Logvf(log.DebugHigh, "MuxIn close %v", muxIn.Intent.Namespace())
+	log.Logvf(log.Trace, "MuxIn close %v", muxIn.Intent.Namespace())
 	if bufferWrites {
 		muxIn.writeChan <- muxIn.buf
 		length := <-muxIn.writeLenChan
@@ -270,7 +270,7 @@ func (muxIn *MuxIn) Close() error {
 // Open is implemented in Mux.open, but in short, it creates chans and a select case
 // and adds the SelectCase and the MuxIn in to the Multiplexer.
 func (muxIn *MuxIn) Open() error {
-	log.Logvf(log.DebugHigh, "MuxIn open %v", muxIn.Intent.Namespace())
+	log.Logvf(log.Trace, "MuxIn open %v", muxIn.Intent.Namespace())
 	muxIn.writeChan = make(chan []byte)
 	muxIn.writeLenChan = make(chan int)
 	muxIn.writeCloseFinishedChan = make(chan struct{})

--- a/archive/prelude.go
+++ b/archive/prelude.go
@@ -135,7 +135,7 @@ func (prelude *Prelude) AddMetadata(cm *CollectionMetadata) {
 		prelude.DBS = append(prelude.DBS, cm.Database)
 	}
 	prelude.NamespaceMetadatasByDB[cm.Database] = append(prelude.NamespaceMetadatasByDB[cm.Database], cm)
-	log.Logvf(log.Debug, "archive prelude %v.%v", cm.Database, cm.Collection)
+	log.Logvf(log.Debug, false, "archive prelude %v.%v", cm.Database, cm.Collection)
 }
 
 // Write writes the archive header.

--- a/archive/prelude.go
+++ b/archive/prelude.go
@@ -135,7 +135,7 @@ func (prelude *Prelude) AddMetadata(cm *CollectionMetadata) {
 		prelude.DBS = append(prelude.DBS, cm.Database)
 	}
 	prelude.NamespaceMetadatasByDB[cm.Database] = append(prelude.NamespaceMetadatasByDB[cm.Database], cm)
-	log.Logvf(log.Info, "archive prelude %v.%v", cm.Database, cm.Collection)
+	log.Logvf(log.Debug, "archive prelude %v.%v", cm.Database, cm.Collection)
 }
 
 // Write writes the archive header.

--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -125,7 +125,7 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 	}
 	if converted {
 		newJSONString := CreateExtJSONString(indexKey)
-		log.Logvf(log.Always, "convertLegacyIndexes: converted index values '%s' to '%s' on collection '%s'",
+		log.Logvf(log.Info, "convertLegacyIndexes: converted index values '%s' to '%s' on collection '%s'",
 			originalJSONString, newJSONString, ns)
 	}
 }
@@ -146,7 +146,7 @@ func ConvertLegacyIndexOptions(indexOptions bson.M) {
 	}
 	if converted {
 		newJSONString := CreateExtJSONString(indexOptions)
-		log.Logvf(log.Always, "convertLegacyIndexes: converted index options '%s' to '%s'",
+		log.Logvf(log.Info, "convertLegacyIndexes: converted index options '%s' to '%s'",
 			originalJSONString, newJSONString)
 	}
 }
@@ -169,7 +169,7 @@ func ConvertLegacyIndexOptionsFromOp(indexOptions *bson.D) {
 	}
 	if converted {
 		newJSONString := CreateExtJSONString(indexOptions)
-		log.Logvf(log.Always, "ConvertLegacyIndexOptionsFromOp: converted index options '%s' to '%s'",
+		log.Logvf(log.Info, "ConvertLegacyIndexOptionsFromOp: converted index options '%s' to '%s'",
 			originalJSONString, newJSONString)
 	}
 }

--- a/bsonutil/indexes.go
+++ b/bsonutil/indexes.go
@@ -125,7 +125,7 @@ func ConvertLegacyIndexKeys(indexKey bson.D, ns string) {
 	}
 	if converted {
 		newJSONString := CreateExtJSONString(indexKey)
-		log.Logvf(log.Info, "convertLegacyIndexes: converted index values '%s' to '%s' on collection '%s'",
+		log.Logvf(log.Info, false, "convertLegacyIndexes: converted index values '%s' to '%s' on collection '%s'",
 			originalJSONString, newJSONString, ns)
 	}
 }
@@ -146,7 +146,7 @@ func ConvertLegacyIndexOptions(indexOptions bson.M) {
 	}
 	if converted {
 		newJSONString := CreateExtJSONString(indexOptions)
-		log.Logvf(log.Info, "convertLegacyIndexes: converted index options '%s' to '%s'",
+		log.Logvf(log.Info, false, "convertLegacyIndexes: converted index options '%s' to '%s'",
 			originalJSONString, newJSONString)
 	}
 }
@@ -169,7 +169,7 @@ func ConvertLegacyIndexOptionsFromOp(indexOptions *bson.D) {
 	}
 	if converted {
 		newJSONString := CreateExtJSONString(indexOptions)
-		log.Logvf(log.Info, "ConvertLegacyIndexOptionsFromOp: converted index options '%s' to '%s'",
+		log.Logvf(log.Info, false, "ConvertLegacyIndexOptionsFromOp: converted index options '%s' to '%s'",
 			originalJSONString, newJSONString)
 	}
 }

--- a/db/db.go
+++ b/db/db.go
@@ -478,10 +478,10 @@ func FilterError(stopOnError bool, err error) error {
 		// Just log the error but don't propagate it.
 		if bwe, ok := err.(mongo.BulkWriteException); ok {
 			for _, be := range bwe.WriteErrors {
-				log.Logvf(log.Error, continueThroughErrorFormat, be.Message)
+				log.Logvf(log.Error, false, continueThroughErrorFormat, be.Message)
 			}
 		} else {
-			log.Logvf(log.Error, continueThroughErrorFormat, err)
+			log.Logvf(log.Error, false, continueThroughErrorFormat, err)
 		}
 		return nil
 	}
@@ -508,7 +508,7 @@ func CanIgnoreError(err error) bool {
 		}
 
 		if mongoErr.WriteConcernError != nil {
-			log.Logvf(log.Error, "write concern error when inserting documents: %v", mongoErr.WriteConcernError)
+			log.Logvf(log.Error, false, "write concern error when inserting documents: %v", mongoErr.WriteConcernError)
 			return false
 		}
 		return true

--- a/db/db.go
+++ b/db/db.go
@@ -478,10 +478,10 @@ func FilterError(stopOnError bool, err error) error {
 		// Just log the error but don't propagate it.
 		if bwe, ok := err.(mongo.BulkWriteException); ok {
 			for _, be := range bwe.WriteErrors {
-				log.Logvf(log.Always, continueThroughErrorFormat, be.Message)
+				log.Logvf(log.Error, continueThroughErrorFormat, be.Message)
 			}
 		} else {
-			log.Logvf(log.Always, continueThroughErrorFormat, err)
+			log.Logvf(log.Error, continueThroughErrorFormat, err)
 		}
 		return nil
 	}
@@ -508,7 +508,7 @@ func CanIgnoreError(err error) bool {
 		}
 
 		if mongoErr.WriteConcernError != nil {
-			log.Logvf(log.Always, "write concern error when inserting documents: %v", mongoErr.WriteConcernError)
+			log.Logvf(log.Error, "write concern error when inserting documents: %v", mongoErr.WriteConcernError)
 			return false
 		}
 		return true

--- a/db/namespaces.go
+++ b/db/namespaces.go
@@ -44,7 +44,7 @@ func (ci *CollectionInfo) GetUUID() string {
 				return hex.EncodeToString(x.Data)
 			}
 		default:
-			log.Logvf(log.DebugHigh, "unknown UUID BSON type '%T'", v)
+			log.Logvf(log.Trace, "unknown UUID BSON type '%T'", v)
 		}
 	}
 	return ""

--- a/db/namespaces.go
+++ b/db/namespaces.go
@@ -44,7 +44,7 @@ func (ci *CollectionInfo) GetUUID() string {
 				return hex.EncodeToString(x.Data)
 			}
 		default:
-			log.Logvf(log.Trace, "unknown UUID BSON type '%T'", v)
+			log.Logvf(log.Trace, false, "unknown UUID BSON type '%T'", v)
 		}
 	}
 	return ""

--- a/db/write_concern.go
+++ b/db/write_concern.go
@@ -34,7 +34,7 @@ func NewMongoWriteConcern(writeConcern string, cs *connstring.ConnString) (wc *w
 	// Log whatever write concern was generated
 	defer func() {
 		if wc != nil {
-			log.Logvf(log.Info, "using write concern: %v", wc)
+			log.Logvf(log.Debug, "using write concern: %v", wc)
 		}
 	}()
 

--- a/db/write_concern.go
+++ b/db/write_concern.go
@@ -34,7 +34,7 @@ func NewMongoWriteConcern(writeConcern string, cs *connstring.ConnString) (wc *w
 	// Log whatever write concern was generated
 	defer func() {
 		if wc != nil {
-			log.Logvf(log.Debug, "using write concern: %v", wc)
+			log.Logvf(log.Debug, false, "using write concern: %v", wc)
 		}
 	}()
 

--- a/intents/intent.go
+++ b/intents/intent.go
@@ -298,7 +298,7 @@ func (mgr *Manager) putNormalIntentWithNamespace(ns string, intent *Intent) {
 // Put inserts an intent into the manager with the same source namespace as
 // its destinations.
 func (mgr *Manager) Put(intent *Intent) {
-	log.Logvf(log.DebugLow, "enqueued collection '%v'", intent.Namespace())
+	log.Logvf(log.Trace, "enqueued collection '%v'", intent.Namespace())
 	mgr.PutWithNamespace(intent.Namespace(), intent)
 }
 
@@ -467,13 +467,13 @@ func (mgr *Manager) AuthVersion() *Intent {
 func (mgr *Manager) Finalize(pType PriorityType) {
 	switch pType {
 	case Legacy:
-		log.Logv(log.DebugHigh, "finalizing intent manager with legacy prioritizer")
+		log.Logv(log.Trace, "finalizing intent manager with legacy prioritizer")
 		mgr.prioritizer = newLegacyPrioritizer(mgr.intentsByDiscoveryOrder)
 	case LongestTaskFirst:
-		log.Logv(log.DebugHigh, "finalizing intent manager with longest task first prioritizer")
+		log.Logv(log.Trace, "finalizing intent manager with longest task first prioritizer")
 		mgr.prioritizer = newLongestTaskFirstPrioritizer(mgr.intentsByDiscoveryOrder)
 	case MultiDatabaseLTF:
-		log.Logv(log.DebugHigh, "finalizing intent manager with multi-database longest task first prioritizer")
+		log.Logv(log.Trace, "finalizing intent manager with multi-database longest task first prioritizer")
 		mgr.prioritizer = newMultiDatabaseLTFPrioritizer(mgr.intentsByDiscoveryOrder)
 	default:
 		panic("cannot initialize IntentPrioritizer with unknown type")

--- a/intents/intent.go
+++ b/intents/intent.go
@@ -298,7 +298,7 @@ func (mgr *Manager) putNormalIntentWithNamespace(ns string, intent *Intent) {
 // Put inserts an intent into the manager with the same source namespace as
 // its destinations.
 func (mgr *Manager) Put(intent *Intent) {
-	log.Logvf(log.Trace, "enqueued collection '%v'", intent.Namespace())
+	log.Logvf(log.Trace, false, "enqueued collection '%v'", intent.Namespace())
 	mgr.PutWithNamespace(intent.Namespace(), intent)
 }
 
@@ -467,13 +467,13 @@ func (mgr *Manager) AuthVersion() *Intent {
 func (mgr *Manager) Finalize(pType PriorityType) {
 	switch pType {
 	case Legacy:
-		log.Logv(log.Trace, "finalizing intent manager with legacy prioritizer")
+		log.Logv(log.Trace, false, "finalizing intent manager with legacy prioritizer")
 		mgr.prioritizer = newLegacyPrioritizer(mgr.intentsByDiscoveryOrder)
 	case LongestTaskFirst:
-		log.Logv(log.Trace, "finalizing intent manager with longest task first prioritizer")
+		log.Logv(log.Trace, false, "finalizing intent manager with longest task first prioritizer")
 		mgr.prioritizer = newLongestTaskFirstPrioritizer(mgr.intentsByDiscoveryOrder)
 	case MultiDatabaseLTF:
-		log.Logv(log.Trace, "finalizing intent manager with multi-database longest task first prioritizer")
+		log.Logv(log.Trace, false, "finalizing intent manager with multi-database longest task first prioritizer")
 		mgr.prioritizer = newMultiDatabaseLTFPrioritizer(mgr.intentsByDiscoveryOrder)
 	default:
 		panic("cannot initialize IntentPrioritizer with unknown type")

--- a/log/tool_logger.go
+++ b/log/tool_logger.go
@@ -18,17 +18,17 @@ import (
 // Tool Logger verbosity constants
 const (
 	Error = iota
-	Warn
-	Info
 	Debug
 	Trace
+	Warn
+	Info
 )
 
 const (
 	ToolTimeFormat = "2006-01-02T15:04:05.000-0700"
 )
 
-var errAbbreviations = []string{"ERR", "WRN", "INF", "DEB", "TRC"}
+var errAbbreviations = []string{"ERR", "DEB", "TRC", "WRN", "INF"}
 
 //// Tool Logger Definition
 
@@ -70,7 +70,11 @@ func (tl *ToolLogger) Logvf(minVerb int, printLogType bool, format string, a ...
 		panic("cannot set a minimum log verbosity that is less than 0")
 	}
 
-	if minVerb <= tl.verbosity {
+	logLevel := minVerb
+	if minVerb == Error || minVerb == Info || minVerb == Warn {
+		logLevel = 0
+	}
+	if logLevel <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
 		if printLogType {
@@ -86,7 +90,11 @@ func (tl *ToolLogger) Logv(minVerb int, printLogType bool, msg string) {
 		panic("cannot set a minimum log verbosity that is less than 0")
 	}
 
-	if minVerb <= tl.verbosity {
+	logLevel := minVerb
+	if minVerb == Error || minVerb == Info || minVerb == Warn {
+		logLevel = 0
+	}
+	if logLevel <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
 		if printLogType {

--- a/log/tool_logger.go
+++ b/log/tool_logger.go
@@ -73,7 +73,7 @@ func (tl *ToolLogger) Logvf(minVerb int, format string, a ...interface{}) {
 	if minVerb <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
-		tl.log(fmt.Sprintf(errAbbreviations[minVerb] + format, a...))
+		tl.log(fmt.Sprintf(errAbbreviations[minVerb] + " " + format, a...))
 	}
 }
 
@@ -85,7 +85,7 @@ func (tl *ToolLogger) Logv(minVerb int, msg string) {
 	if minVerb <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
-		tl.log(errAbbreviations[minVerb] + msg)
+		tl.log(errAbbreviations[minVerb] + " " + msg)
 	}
 }
 

--- a/log/tool_logger.go
+++ b/log/tool_logger.go
@@ -65,7 +65,7 @@ func (tl *ToolLogger) SetDateFormat(dateFormat string) {
 	tl.format = dateFormat
 }
 
-func (tl *ToolLogger) Logvf(minVerb int, format string, a ...interface{}) {
+func (tl *ToolLogger) Logvf(minVerb int, printLogType bool, format string, a ...interface{}) {
 	if minVerb < 0 {
 		panic("cannot set a minimum log verbosity that is less than 0")
 	}
@@ -73,11 +73,15 @@ func (tl *ToolLogger) Logvf(minVerb int, format string, a ...interface{}) {
 	if minVerb <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
-		tl.log(fmt.Sprintf(errAbbreviations[minVerb] + " " + format, a...))
+		if printLogType {
+			tl.log(fmt.Sprintf(errAbbreviations[minVerb] + " " + format, a...))
+		} else {
+			tl.log(fmt.Sprintf(format, a...))
+		}
 	}
 }
 
-func (tl *ToolLogger) Logv(minVerb int, msg string) {
+func (tl *ToolLogger) Logv(minVerb int, printLogType bool, msg string) {
 	if minVerb < 0 {
 		panic("cannot set a minimum log verbosity that is less than 0")
 	}
@@ -85,7 +89,12 @@ func (tl *ToolLogger) Logv(minVerb int, msg string) {
 	if minVerb <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
-		tl.log(errAbbreviations[minVerb] + " " + msg)
+		if printLogType {
+			tl.log(errAbbreviations[minVerb] + " " + msg)
+		} else {
+			tl.log(msg)
+		}
+
 	}
 }
 
@@ -113,7 +122,7 @@ type toolLogWriter struct {
 }
 
 func (tlw *toolLogWriter) Write(message []byte) (int, error) {
-	tlw.logger.Logv(tlw.minVerbosity, string(message))
+	tlw.logger.Logv(tlw.minVerbosity, false, string(message))
 	return len(message), nil
 }
 
@@ -140,12 +149,12 @@ func IsInVerbosity(minVerb int) bool {
 	return minVerb <= globalToolLogger.verbosity
 }
 
-func Logvf(minVerb int, format string, a ...interface{}) {
-	globalToolLogger.Logvf(minVerb, format, a...)
+func Logvf(minVerb int, printLogType bool, format string, a ...interface{}) {
+	globalToolLogger.Logvf(minVerb, printLogType, format, a...)
 }
 
-func Logv(minVerb int, msg string) {
-	globalToolLogger.Logv(minVerb, msg)
+func Logv(minVerb int, printLogType bool, msg string) {
+	globalToolLogger.Logv(minVerb, printLogType, msg)
 }
 
 func SetVerbosity(verbosity VerbosityLevel) {

--- a/log/tool_logger.go
+++ b/log/tool_logger.go
@@ -17,15 +17,18 @@ import (
 
 // Tool Logger verbosity constants
 const (
-	Always = iota
+	Error = iota
+	Warn
 	Info
-	DebugLow
-	DebugHigh
+	Debug
+	Trace
 )
 
 const (
 	ToolTimeFormat = "2006-01-02T15:04:05.000-0700"
 )
+
+var errAbbreviations = []string{"ERR", "WRN", "INF", "DEB", "TRC"}
 
 //// Tool Logger Definition
 
@@ -70,7 +73,7 @@ func (tl *ToolLogger) Logvf(minVerb int, format string, a ...interface{}) {
 	if minVerb <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
-		tl.log(fmt.Sprintf(format, a...))
+		tl.log(fmt.Sprintf(errAbbreviations[minVerb] + ": " + format, a...))
 	}
 }
 
@@ -82,7 +85,7 @@ func (tl *ToolLogger) Logv(minVerb int, msg string) {
 	if minVerb <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
-		tl.log(msg)
+		tl.log(errAbbreviations[minVerb] + ": " + msg)
 	}
 }
 

--- a/log/tool_logger.go
+++ b/log/tool_logger.go
@@ -73,7 +73,7 @@ func (tl *ToolLogger) Logvf(minVerb int, format string, a ...interface{}) {
 	if minVerb <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
-		tl.log(fmt.Sprintf(errAbbreviations[minVerb] + ": " + format, a...))
+		tl.log(fmt.Sprintf(errAbbreviations[minVerb] + format, a...))
 	}
 }
 
@@ -85,7 +85,7 @@ func (tl *ToolLogger) Logv(minVerb int, msg string) {
 	if minVerb <= tl.verbosity {
 		tl.mutex.Lock()
 		defer tl.mutex.Unlock()
-		tl.log(errAbbreviations[minVerb] + ": " + msg)
+		tl.log(errAbbreviations[minVerb] + msg)
 	}
 }
 

--- a/log/tool_logger_test.go
+++ b/log/tool_logger_test.go
@@ -41,7 +41,7 @@ func TestBasicToolLoggerFunctionality(t *testing.T) {
 		So(tl.verbosity, ShouldEqual, 3)
 
 		Convey("writing a negative verbosity should panic", func() {
-			So(func() { tl.Logvf(-1, "nope") }, ShouldPanic)
+			So(func() { tl.Logvf(-1, false, "nope") }, ShouldPanic)
 		})
 
 		Convey("writing the output to a buffer", func() {
@@ -49,9 +49,9 @@ func TestBasicToolLoggerFunctionality(t *testing.T) {
 			tl.SetWriter(buf)
 
 			Convey("with Logfs of various verbosity levels", func() {
-				tl.Logvf(0, "test this string")
-				tl.Logvf(5, "this log level is too high and will not log")
-				tl.Logvf(1, "====!%v!====", 12.5)
+				tl.Logvf(0, false, "test this string")
+				tl.Logvf(5, false, "this log level is too high and will not log")
+				tl.Logvf(1, false, "====!%v!====", 12.5)
 
 				Convey("only messages of low enough verbosity should be written", func() {
 					l1, _ := buf.ReadString('\n')
@@ -86,7 +86,7 @@ func TestGlobalToolLoggerFunctionality(t *testing.T) {
 
 		Convey("actions shouldn't panic", func() {
 			So(func() { SetVerbosity(&verbosity{Q: true}) }, ShouldNotPanic)
-			So(func() { Logvf(0, "woooo") }, ShouldNotPanic)
+			So(func() { Logvf(0, false, "woooo") }, ShouldNotPanic)
 			So(func() { SetDateFormat("ahaha") }, ShouldNotPanic)
 			So(func() { SetWriter(os.Stdout) }, ShouldNotPanic)
 		})

--- a/options/options.go
+++ b/options/options.go
@@ -240,7 +240,7 @@ func New(appName, versionStr, gitCommit, usageStr string, parsePositionalArgsAsU
 		} else if val == "" {
 			opts.VLevel = opts.VLevel + 1 // Increment for every occurrence of flag
 		} else {
-			log.Logvf(log.Error, "Invalid verbosity value given")
+			log.Logvf(log.Error, false, "Invalid verbosity value given")
 			os.Exit(-1)
 		}
 	}
@@ -392,7 +392,7 @@ func (opts *ToolOptions) EnabledToolOptions() EnabledOptions {
 // The unknown options are determined by the driver.
 func (uri *URI) LogUnsupportedOptions() {
 	for key := range uri.ConnString.UnknownOptions {
-		log.Logvf(log.Warn, unknownOptionsWarningFormat, key)
+		log.Logvf(log.Warn, false, unknownOptionsWarningFormat, key)
 	}
 }
 
@@ -432,7 +432,7 @@ func (opts *ToolOptions) ParseArgs(args []string) ([]string, error) {
 	}
 
 	if opts.SSLAllowInvalidCert || opts.SSLAllowInvalidHost {
-		log.Logvf(log.Warn, deprecationWarningSSLAllow)
+		log.Logvf(log.Warn, false, deprecationWarningSSLAllow)
 	}
 
 	if opts.parsePositionalArgsAsURI {

--- a/options/options.go
+++ b/options/options.go
@@ -240,7 +240,7 @@ func New(appName, versionStr, gitCommit, usageStr string, parsePositionalArgsAsU
 		} else if val == "" {
 			opts.VLevel = opts.VLevel + 1 // Increment for every occurrence of flag
 		} else {
-			log.Logvf(log.Always, "Invalid verbosity value given")
+			log.Logvf(log.Error, "Invalid verbosity value given")
 			os.Exit(-1)
 		}
 	}
@@ -287,7 +287,7 @@ func New(appName, versionStr, gitCommit, usageStr string, parsePositionalArgsAsU
 	if opts.MaxProcs <= 0 {
 		opts.MaxProcs = runtime.NumCPU()
 	}
-	log.Logvf(log.Info, "Setting num cpus to %v", opts.MaxProcs)
+	log.Logvf(log.Debug, "Setting num cpus to %v", opts.MaxProcs)
 	runtime.GOMAXPROCS(opts.MaxProcs)
 	return opts
 }
@@ -392,7 +392,7 @@ func (opts *ToolOptions) EnabledToolOptions() EnabledOptions {
 // The unknown options are determined by the driver.
 func (uri *URI) LogUnsupportedOptions() {
 	for key := range uri.ConnString.UnknownOptions {
-		log.Logvf(log.Always, unknownOptionsWarningFormat, key)
+		log.Logvf(log.Warn, unknownOptionsWarningFormat, key)
 	}
 }
 
@@ -432,7 +432,7 @@ func (opts *ToolOptions) ParseArgs(args []string) ([]string, error) {
 	}
 
 	if opts.SSLAllowInvalidCert || opts.SSLAllowInvalidHost {
-		log.Logvf(log.Always, deprecationWarningSSLAllow)
+		log.Logvf(log.Warn, deprecationWarningSSLAllow)
 	}
 
 	if opts.parsePositionalArgsAsURI {

--- a/options/options.go
+++ b/options/options.go
@@ -287,7 +287,7 @@ func New(appName, versionStr, gitCommit, usageStr string, parsePositionalArgsAsU
 	if opts.MaxProcs <= 0 {
 		opts.MaxProcs = runtime.NumCPU()
 	}
-	log.Logvf(log.Debug, "Setting num cpus to %v", opts.MaxProcs)
+	log.Logvf(log.Debug, false, "Setting num cpus to %v", opts.MaxProcs)
 	runtime.GOMAXPROCS(opts.MaxProcs)
 	return opts
 }

--- a/password/password.go
+++ b/password/password.go
@@ -32,11 +32,11 @@ func Prompt() (string, error) {
 	var pass string
 	var err error
 	if IsTerminal() {
-		log.Logv(log.DebugLow, "standard input is a terminal; reading password from terminal")
+		log.Logv(log.Trace, "standard input is a terminal; reading password from terminal")
 		fmt.Fprintf(os.Stderr, "Enter password:")
 		pass, err = readPassInteractively()
 	} else {
-		log.Logv(log.Always, "reading password from standard input")
+		log.Logv(log.Info, "reading password from standard input")
 		fmt.Fprintf(os.Stderr, "Enter password:")
 		pass, err = readPassNonInteractively(os.Stdin)
 	}

--- a/password/password.go
+++ b/password/password.go
@@ -32,11 +32,11 @@ func Prompt() (string, error) {
 	var pass string
 	var err error
 	if IsTerminal() {
-		log.Logv(log.Trace, "standard input is a terminal; reading password from terminal")
+		log.Logv(log.Trace, false, "standard input is a terminal; reading password from terminal")
 		fmt.Fprintf(os.Stderr, "Enter password:")
 		pass, err = readPassInteractively()
 	} else {
-		log.Logv(log.Info, "reading password from standard input")
+		log.Logv(log.Info, false, "reading password from standard input")
 		fmt.Fprintf(os.Stderr, "Enter password:")
 		pass, err = readPassNonInteractively(os.Stdin)
 	}

--- a/signals/signals.go
+++ b/signals/signals.go
@@ -37,7 +37,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 	noopChan := make(chan os.Signal)
 	signal.Notify(noopChan, syscall.SIGPIPE)
 
-	log.Logv(log.Trace, "will listen for SIGTERM, SIGINT, and SIGKILL")
+	log.Logv(log.Trace, false, "will listen for SIGTERM, SIGINT, and SIGKILL")
 	sigChan := make(chan os.Signal, 2)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
 	defer signal.Stop(sigChan)
@@ -45,7 +45,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 		select {
 		case sig := <-sigChan:
 			// first signal use finalizer to terminate cleanly
-			log.Logvf(log.Info, "signal '%s' received; attempting to shut down", sig)
+			log.Logvf(log.Info, false, "signal '%s' received; attempting to shut down", sig)
 			finalizer()
 		case <-finishedChan:
 			return
@@ -54,7 +54,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 	select {
 	case sig := <-sigChan:
 		// second signal exits immediately
-		log.Logvf(log.Info, "signal '%s' received; forcefully terminating", sig)
+		log.Logvf(log.Info, false, "signal '%s' received; forcefully terminating", sig)
 		os.Exit(util.ExitFailure)
 	case <-finishedChan:
 		return

--- a/signals/signals.go
+++ b/signals/signals.go
@@ -37,7 +37,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 	noopChan := make(chan os.Signal)
 	signal.Notify(noopChan, syscall.SIGPIPE)
 
-	log.Logv(log.DebugLow, "will listen for SIGTERM, SIGINT, and SIGKILL")
+	log.Logv(log.Trace, "will listen for SIGTERM, SIGINT, and SIGKILL")
 	sigChan := make(chan os.Signal, 2)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT, syscall.SIGKILL)
 	defer signal.Stop(sigChan)
@@ -45,7 +45,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 		select {
 		case sig := <-sigChan:
 			// first signal use finalizer to terminate cleanly
-			log.Logvf(log.Always, "signal '%s' received; attempting to shut down", sig)
+			log.Logvf(log.Info, "signal '%s' received; attempting to shut down", sig)
 			finalizer()
 		case <-finishedChan:
 			return
@@ -54,7 +54,7 @@ func handleSignals(finalizer func(), finishedChan chan struct{}) {
 	select {
 	case sig := <-sigChan:
 		// second signal exits immediately
-		log.Logvf(log.Always, "signal '%s' received; forcefully terminating", sig)
+		log.Logvf(log.Info, "signal '%s' received; forcefully terminating", sig)
 		os.Exit(util.ExitFailure)
 	case <-finishedChan:
 		return


### PR DESCRIPTION
Changes to the log types:
- `log.Always` -> `log.Error` or `log.Info` or `log.Warn`
- `log.Info` -> `log.Debug`
- `log.DebugLow` and `log.DebugHigh` -> `log.Trace`