### PR TITLE
Revert "TOOLS-2707: Build mongo-tools-common with go 1.15"

### DIFF
--- a/json/scanner.go
+++ b/json/scanner.go
@@ -650,7 +650,7 @@ func quoteChar(c int) string {
 	}
 
 	// use quoted string with different quotation marks
-	s := strconv.Quote(string(rune(c)))
+	s := strconv.Quote(string(c))
 	return "'" + s[1:len(s)-1] + "'"
 }
 

--- a/set_goenv.sh
+++ b/set_goenv.sh
@@ -11,14 +11,11 @@ set_goenv() {
     UNAME_S=$(PATH="/usr/bin:/bin" uname -s)
     case $UNAME_S in
         CYGWIN*)
-            PREF_GOROOT="c:/golang/go1.15"
-            PREF_PATH="/cygdrive/c/golang/go1.15/bin:/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin:$PATH"
-            if [[ $GOCACHE != C:* ]]; then
-                export GOCACHE="C:$GOCACHE"
-            fi
+            PREF_GOROOT="c:/golang/go1.11"
+            PREF_PATH="/cygdrive/c/golang/go1.11/bin:/cygdrive/c/mingw-w64/x86_64-4.9.1-posix-seh-rt_v3-rev1/mingw64/bin:$PATH"
         ;;
         *)
-            PREF_GOROOT="/opt/golang/go1.15"
+            PREF_GOROOT="/opt/golang/go1.11"
             # XXX might not need mongodbtoolchain anymore
             PREF_PATH="$PREF_GOROOT/bin:/opt/mongodbtoolchain/v3/bin/:$PATH"
         ;;


### PR DESCRIPTION
The mongo-tools commit was [reverted](https://github.com/mongodb/mongo-tools/pull/313), but the m-t-c one wasn't.