### PR TITLE
TOOLS-2780: Add warning when password value appears on command line

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -529,7 +529,7 @@ func LogSensitiveOptionWarnings(args []string) {
 		}
 
 		// Option has the form --password and the next argument is not the empty string.
-		if strings.HasPrefix(arg, "--password") && i+1 < len(args) && args[i+1] != "" {
+		if arg == "--password" && i+1 < len(args) && args[i+1] != "" {
 			log.Logvf(log.Always, passwordMsg)
 			continue
 		}
@@ -551,7 +551,7 @@ func LogSensitiveOptionWarnings(args []string) {
 			continue
 		}
 		// Option has the form --sslPEMKeyPassword with at least one argument after it.
-		if strings.HasPrefix(arg, "--sslPEMKeyPassword") && i+1 < len(args) {
+		if arg == "--sslPEMKeyPassword" && i+1 < len(args) {
 			log.Logvf(log.Always, sslMsg)
 			continue
 		}

--- a/options/options.go
+++ b/options/options.go
@@ -431,11 +431,11 @@ func (opts *ToolOptions) AddOptions(extraOpts ExtraOptions) {
 // any values in the config file. Returns any extra args not accounted for by parsing,
 // as well as an error if the parsing returns an error.
 func (opts *ToolOptions) ParseArgs(args []string) ([]string, error) {
+	LogSensitiveOptionWarnings(args)
+
 	if err := opts.ParseConfigFile(args); err != nil {
 		return []string{}, err
 	}
-
-	opts.LogSensitiveOptionWarnings(args)
 
 	args, err := opts.parser.ParseArgs(args)
 	if err != nil {
@@ -461,6 +461,56 @@ func (opts *ToolOptions) ParseArgs(args []string) ([]string, error) {
 	}
 
 	return args, err
+}
+
+// LogSensitiveOptionWarnings logs a warning for any sensitive information (i.e. passwords)
+// that appear on the command line for the --password, --uri and --sslPEMKeyPassword options.
+// This also applies to a connection string that appears as a positional argument.
+func LogSensitiveOptionWarnings(args []string) {
+	passwordMsg := "WARNING: On some systems, a password provided directly using " +
+		"--password may be visible to system status programs such as `ps` that may be " +
+		"invoked by other users. Consider omitting the password to provide it via stdin, " +
+		"or using the --config option to specify a configuration file with the password."
+
+	uriMsg := "WARNING: On some systems, a password provided directly in a connection string " +
+		"or using --uri may be visible to system status programs such as `ps` that may be " +
+		"invoked by other users. Consider omitting the password to provide it via stdin, " +
+		"or using the --config option to specify a configuration file with the password."
+
+	sslMsg := "WARNING: On some systems, a password provided directly using --sslPEMKeyPassword " +
+		"may be visible to system status programs such as `ps` that may be invoked by other users. " +
+		"Consider using the --config option to specify a configuration file with the password."
+
+	// Create temporary options for parsing command line args.
+	tempOpts := New("", "", "", "", true, EnabledOptions{Auth: true, Connection: true, URI: true})
+	extraArgs, err := tempOpts.parser.ParseArgs(args)
+	if err != nil {
+		return
+	}
+
+	// Parse the extraArgs for a positional connection string.
+	_, err = tempOpts.setURIFromPositionalArg(extraArgs)
+	if err != nil {
+		return
+	}
+
+	// Log a message for --password, if specified.
+	if tempOpts.Auth.Password != "" {
+		log.Logvf(log.Always, passwordMsg)
+	}
+
+	// Log a message for --uri or a positional connection string, if either is specified.
+	uri := tempOpts.URI.ConnectionString
+	if uri != "" {
+		if cs, err := connstring.Parse(uri); err == nil && cs.Password != "" {
+			log.Logvf(log.Always, uriMsg)
+		}
+	}
+
+	// Log a message for --sslPEMKeyPassword, if specified.
+	if tempOpts.SSL.SSLPEMKeyPassword != "" {
+		log.Logvf(log.Always, sslMsg)
+	}
 }
 
 // ParseConfigFile iterates over args to find a --config option. If not found, we return.
@@ -502,60 +552,6 @@ func (opts *ToolOptions) ParseConfigFile(args []string) error {
 	opts.SSL.SSLPEMKeyPassword = config.SSLPEMKeyPassword
 
 	return nil
-}
-
-// LogSensitiveOptionWarnings logs a warning for any sensitive information (i.e. passwords)
-// that appear on the command line for the --password, --uri and --sslPEMKeyPassword options.
-// This also applies to a connection string that appears as a positional argument.
-func (opts *ToolOptions) LogSensitiveOptionWarnings(args []string) {
-	passwordMsg := "WARNING: On some systems, a password provided directly using " +
-		"--password may be visible to system status programs such as `ps` that may be " +
-		"invoked by other users. Consider omitting the password to provide it via stdin, " +
-		"or using the --config option to specify a configuration file with the password."
-
-	uriMsg := "WARNING: On some systems, a password provided directly in a connection string " +
-		"or using --uri may be visible to system status programs such as `ps` that may be " +
-		"invoked by other users. Consider omitting the password to provide it via stdin, " +
-		"or using the --config option to specify a configuration file with the password."
-
-	sslMsg := "WARNING: On some systems, a password provided directly using --sslPEMKeyPassword " +
-		"may be visible to system status programs such as `ps` that may be invoked by other users. " +
-		"Consider using the --config option to specify a configuration file with the password."
-
-	// Parse the args to see what is set on the command line.
-	extraArgs, err := opts.parser.ParseArgs(args)
-	if err != nil {
-		return
-	}
-
-	// Parse the extraArgs for a positional connection string.
-	if opts.parsePositionalArgsAsURI {
-		_, err = opts.setURIFromPositionalArg(extraArgs)
-		if err != nil {
-			return
-		}
-	}
-
-	// Log a message for --password, if specified.
-	if opts.Auth.Password != "" {
-		log.Logvf(log.Always, passwordMsg)
-		opts.Auth.Password = ""
-	}
-
-	// Log a message for --uri or a positional connection string, if either is specified.
-	uri := opts.URI.ConnectionString
-	if uri != "" {
-		if cs, err := connstring.Parse(uri); err == nil && cs.Password != "" {
-			log.Logvf(log.Always, uriMsg)
-		}
-		opts.URI.ConnectionString = ""
-	}
-
-	// Log a message for --sslPEMKeyPassword, if specified.
-	if opts.SSL.SSLPEMKeyPassword != "" {
-		log.Logvf(log.Always, sslMsg)
-		opts.SSL.SSLPEMKeyPassword = ""
-	}
 }
 
 func (opts *ToolOptions) setURIFromPositionalArg(args []string) ([]string, error) {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/TOOLS-2780

This just checks the command line args and logs a warning if a non-empty string appears for `--password`, `--uri` and `--sslPEMKeyPassword`, along with passwords in connection strings which are positional args.

Here's a list of the different use cases that show when the warning is logged:
```
#################
# Shows warning #
#################


$ mongodump --username "abc" --password "def"
2020-11-24T16:41:57.384-0500	WARNING: On some systems, a password provided directly
using --password may be visible to system status programs such as `ps` that may be invoked
by other users. Consider omitting the password to provide it via stdin, or using the --config
option to specify a configuration file with the password.

$ mongodump --username "abc" --password="def"
2020-11-24T16:42:58.970-0500	WARNING: On some systems, ...

$ mongodump --password "def"
2020-11-24T16:44:02.664-0500	WARNING: On some systems, ...

$ mongodump --password="def"
2020-11-24T16:44:40.987-0500	WARNING: On some systems, ...

$ mongodump --password=def
2020-11-24T16:45:33.536-0500	WARNING: On some systems, ...


$ mongodump --uri "mongodb://abc:def@localhost:33333"
2020-11-24T16:46:39.701-0500	WARNING: On some systems, a password provided directly
using --uri may be visible to system status programs such as `ps` that may be invoked by
other users. Consider omitting the password to provide it via stdin, or using the --config
option to specify a configuration file with the password.

$ mongodump --uri="mongodb://abc:def@localhost:33333"
2020-11-24T16:48:55.758-0500	WARNING: On some systems, ...

$ mongodump "mongodb://abc:def@localhost:33333"
2020-11-24T16:49:25.584-0500	WARNING: On some systems, ...

$ mongodump mongodb://abc:def@localhost:33333
2020-11-24T16:50:07.803-0500	WARNING: On some systems, ...


$ mongodump --sslPEMKeyPassword "def"
2020-11-24T16:50:52.180-0500	WARNING: On some systems, a password provided directly using
--sslPEMKeyPassword may be visible to system status programs such as `ps` that may be invoked by
other users. Consider using the --config option to specify a configuration file with the password.

$ mongodump --sslPEMKeyPassword="abc"
2020-11-24T16:51:25.939-0500	WARNING: On some systems, ...



##############
# No warning #
##############


$ mongodump --username "abc" --password ""
Enter password:

$ mongodump --username "abc" --password ''
Enter password:

$ mongodump --username "abc" --password=""
Enter password:

$ mongodump --username "abc" --password=''
Enter password:

$ mongodump --username "abc" --password=
Enter password:


$ mongodump --uri "mongodb://abc:@localhost:33333"
Enter password:

$ mongodump --uri="mongodb://abc:@localhost:33333"
Enter password:

$ mongodump "mongodb://abc:@localhost:33333"
Enter password:

$ mongodump mongodb://abc:@localhost:33333
Enter password:

$ mongodump mongodb://abc@localhost:33333
Enter password:
```